### PR TITLE
feat: /context dashboard — worker usage ledger, inspect/summary methods, CLI board

### DIFF
--- a/agent/application/context/__init__.py
+++ b/agent/application/context/__init__.py
@@ -3,6 +3,8 @@
 from .compaction import CompactionService
 from .estimator import ContextBudget, ContextEstimate, ContextEstimator
 from .manager import ContextBuildResult, ContextManager
+from .snapshot import build_context_snapshot
+from .usage_summary import summarize_usage
 
 __all__ = [
     "CompactionService",
@@ -11,4 +13,7 @@ __all__ = [
     "ContextEstimate",
     "ContextEstimator",
     "ContextManager",
+    "build_context_snapshot",
+    "summarize_usage",
 ]
+

--- a/agent/application/context/compaction.py
+++ b/agent/application/context/compaction.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
@@ -17,7 +18,7 @@ from agent.prompts import build_compact_prompt
 
 from .estimator import DEFAULT_CONTEXT_WINDOW_TOKENS
 from .handoff import CompactionHandoffBuilder
-from .token_usage import normalize_sampling_usage, positive_int
+from .token_usage import build_usage_record, normalize_sampling_usage, positive_int
 
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,7 @@ class CompactionService:
     max_excerpt_chars: int = 2000
     max_compact_prompt_chars: int = 100000
     plan_snapshot_provider: Callable[[], str] | None = None
+    usage_recorder: Callable[[dict[str, Any]], Any] | None = None
 
     async def compact_async(
         self,
@@ -81,6 +83,7 @@ class CompactionService:
                 usage_error = await self._try_persist_sampling_usage(session, usage)
                 if usage_error:
                     record["usage_persist_error"] = usage_error
+                await self._record_usage(session, usage)
         except Exception as exc:
             record["strategy"] = "deterministic_fallback"
             record["fallback_error"] = {
@@ -358,6 +361,23 @@ class CompactionService:
         except Exception as exc:
             return {"type": type(exc).__name__, "message": str(exc)}
         return None
+
+    async def _record_usage(self, session, usage: dict[str, Any]) -> None:
+        """Best-effort append to the user-level ledger; compaction samples stay counted."""
+        recorder = self.usage_recorder
+        if recorder is None or not isinstance(usage, dict):
+            return
+        record = build_usage_record(
+            usage,
+            session_id=str(getattr(session, "session_id", "") or ""),
+            model=str(getattr(session, "model", "") or ""),
+        )
+        try:
+            await asyncio.to_thread(recorder, record)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("Usage ledger append failed.", exc_info=True)
 
     def _limit_prompt_payload(self, payload: str) -> str:
         if len(payload) <= self.max_compact_prompt_chars:

--- a/agent/application/context/manager.py
+++ b/agent/application/context/manager.py
@@ -32,6 +32,9 @@ class ContextBuildResult:
     messages: list[dict]
     stats: dict = field(default_factory=dict)
     decisions: dict = field(default_factory=dict)
+    # Pre-strip copy of `messages` that keeps `_context_kind` tags so the
+    # composition snapshot buckets injections the way the pipeline built them.
+    internal_messages: list[dict] = field(default_factory=list)
 
 
 class ContextManager:
@@ -99,12 +102,15 @@ class ContextManager:
         )
 
         final_messages = [self._strip_internal_fields(message) for message in messages]
-        final_estimate = self._estimator.estimate_messages(final_messages)
+        # Score the tagged list, not the stripped projection: the composition
+        # snapshot re-estimates these exact payloads, keeping section sums
+        # equal to stats["estimated_input_tokens"] with zero drift.
+        final_estimate = self._estimator.estimate_messages(messages)
 
         dropped_count = 0
         while allow_rescue and final_estimate.over_hard_limit and len(final_messages) > 2:
             messages, final_messages = self.rescue_context(messages, final_messages)
-            final_estimate = self._estimator.estimate_messages(final_messages)
+            final_estimate = self._estimator.estimate_messages(messages)
             dropped_count += 1
             if dropped_count > 50:
                 break
@@ -145,7 +151,12 @@ class ContextManager:
             **rind_decisions,
             **skill_decisions,
         }
-        return ContextBuildResult(messages=final_messages, stats=stats, decisions=decisions)
+        return ContextBuildResult(
+            messages=final_messages,
+            stats=stats,
+            decisions=decisions,
+            internal_messages=[dict(message) for message in messages],
+        )
 
     async def _build_token_pressure_status(self, session, final_estimate) -> dict:
         budget = self._estimator.budget

--- a/agent/application/context/snapshot.py
+++ b/agent/application/context/snapshot.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Callable
 
 from agent.domain.compaction import (

--- a/agent/application/context/snapshot.py
+++ b/agent/application/context/snapshot.py
@@ -35,11 +35,13 @@ def build_context_snapshot(
     captured_at: str | None = None,
     estimator: ContextEstimator | None = None,
 ) -> dict[str, Any]:
-    """Bucket the assembled message list into sections with estimated tokens.
+    """Bucket the assembled message list into sections with per-message estimates.
 
     Pure function: fixed input produces the same sections. The total is taken
     from the pipeline's own stats (never re-summed), so per-section estimates
     share the exact per-message payloads the estimator scored at build time.
+    Sections are ordered by first appearance in the assembly; the array
+    position is the only order carrier (no extra field is emitted).
     """
     stats = stats if isinstance(stats, dict) else {}
     sections = _build_sections(messages, estimator or ContextEstimator())
@@ -54,59 +56,60 @@ def build_context_snapshot(
             stats.get("context_window_tokens"),
             DEFAULT_CONTEXT_WINDOW_TOKENS,
         ),
-        "sections": sorted(sections, key=lambda section: (-section["tokens"], section["key"])),
+        "sections": sorted(sections, key=lambda section: section.pop("_order")),
     }
 
 
 def _build_sections(messages: list[dict], estimator: ContextEstimator) -> list[dict[str, Any]]:
     buckets: dict[str, dict[str, Any]] = {}
 
-    def assign(key: str, label: str, tokens: int) -> None:
+    def assign(key: str, label: str, tokens: int, order: int) -> None:
         bucket = buckets.get(key)
         if bucket is None:
-            bucket = {"key": key, "label": label, "tokens": 0, "messages": 0}
+            bucket = {"key": key, "label": label, "tokens": 0, "messages": 0, "_order": order}
             buckets[key] = bucket
         bucket["tokens"] += max(0, int(tokens))
         bucket["messages"] += 1
 
     tool_names = _tool_names_by_call_id(messages)
     top_tools = _top_tool_names(messages, tool_names)
-    for message in messages if isinstance(messages, list) else []:
+    for index, message in enumerate(messages if isinstance(messages, list) else []):
         if not isinstance(message, dict):
             continue
         kind = message.get("_context_kind")
         if isinstance(kind, str) and kind.strip():
-            _assign_context_kind(assign, message, kind.strip(), estimator)
+            _assign_context_kind(assign, message, kind.strip(), estimator, index)
             continue
         role = message.get("role")
         if role == "tool":
             name = tool_names.get(str(message.get("tool_call_id") or "")) or "unknown"
             if name in top_tools:
-                assign(f"tool:{name}", f"Tool results · {name}", _estimate(estimator, message))
+                assign(f"tool:{name}", f"Tool results · {name}", _estimate(estimator, message), index)
             else:
-                assign("tool:other", "Tool results · other", _estimate(estimator, message))
+                assign("tool:other", "Tool results · other", _estimate(estimator, message), index)
             continue
         if _is_compaction_handoff(message):
-            assign("compaction_handoff", "Compaction handoff", _estimate(estimator, message))
+            assign("compaction_handoff", "Compaction handoff", _estimate(estimator, message), index)
             continue
         if role == "system":
-            assign("system_prompt", "System prompt (incl. capsule)", _estimate(estimator, message))
+            assign("system_prompt", "System prompt (incl. capsule)", _estimate(estimator, message), index)
         elif role == "user":
-            assign("chat_user", "Chat · user inputs", _estimate(estimator, message))
+            assign("chat_user", "Chat · user inputs", _estimate(estimator, message), index)
         elif role == "assistant":
-            _assign_assistant(assign, message, estimator)
+            _assign_assistant(assign, message, estimator, index)
         else:
             # Unknown roles form their own bucket under their original name.
             label = str(role or "unknown")
-            assign(f"role:{label}", label, _estimate(estimator, message))
+            assign(f"role:{label}", label, _estimate(estimator, message), index)
     return list(buckets.values())
 
 
 def _assign_context_kind(
-    assign: Callable[[str, str, int], None],
+    assign: Callable[[str, str, int, int], None],
     message: dict,
     kind: str,
     estimator: ContextEstimator,
+    order: int,
 ) -> None:
     total = _estimate(estimator, message)
     if kind == "rind_docs":
@@ -117,29 +120,30 @@ def _assign_context_kind(
         if has_user and has_project:
             user_segment = content.split(RIND_DOC_USER_MARKER, 1)[1].split(RIND_DOC_PROJECT_MARKER, 1)[0]
             user_tokens = min(total, _estimate(estimator, {"role": "system", "content": user_segment}))
-            assign("rind_docs_user", "RIND.md · user", user_tokens)
-            assign("rind_docs_project", "RIND.md · project", total - user_tokens)
+            assign("rind_docs_user", "RIND.md · user", user_tokens, order)
+            assign("rind_docs_project", "RIND.md · project", total - user_tokens, order)
             return
         if has_user:
-            assign("rind_docs_user", "RIND.md · user", total)
+            assign("rind_docs_user", "RIND.md · user", total, order)
             return
         if has_project:
-            assign("rind_docs_project", "RIND.md · project", total)
+            assign("rind_docs_project", "RIND.md · project", total, order)
             return
-        assign("rind_docs", "RIND.md", total)
+        assign("rind_docs", "RIND.md", total, order)
         return
     # Unknown tags form their own bucket, displayed under their original name.
     label = _CONTEXT_KIND_LABELS.get(kind, kind)
     if label is kind:
-        assign(f"kind:{kind}", kind, total)
+        assign(f"kind:{kind}", kind, total, order)
         return
-    assign(kind, label, total)
+    assign(kind, label, total, order)
 
 
 def _assign_assistant(
-    assign: Callable[[str, str, int], None],
+    assign: Callable[[str, str, int, int], None],
     message: dict,
     estimator: ContextEstimator,
+    order: int,
 ) -> None:
     total = _estimate(estimator, message)
     reasoning = message.get("reasoning_content")
@@ -148,10 +152,10 @@ def _assign_assistant(
             total,
             _estimate(estimator, {"role": "assistant", "reasoning_content": reasoning}),
         )
-        assign("chat_assistant", "Chat · assistant replies", total - reasoning_tokens)
-        assign("reasoning", "Reasoning content", reasoning_tokens)
+        assign("chat_assistant", "Chat · assistant replies", total - reasoning_tokens, order)
+        assign("reasoning", "Reasoning content", reasoning_tokens, order)
         return
-    assign("chat_assistant", "Chat · assistant replies", total)
+    assign("chat_assistant", "Chat · assistant replies", total, order)
 
 
 def _is_compaction_handoff(message: dict) -> bool:

--- a/agent/application/context/snapshot.py
+++ b/agent/application/context/snapshot.py
@@ -129,7 +129,11 @@ def _assign_context_kind(
         assign("rind_docs", "RIND.md", total)
         return
     # Unknown tags form their own bucket, displayed under their original name.
-    assign(f"kind:{kind}", _CONTEXT_KIND_LABELS.get(kind, kind), total)
+    label = _CONTEXT_KIND_LABELS.get(kind, kind)
+    if label is kind:
+        assign(f"kind:{kind}", kind, total)
+        return
+    assign(kind, label, total)
 
 
 def _assign_assistant(

--- a/agent/application/context/snapshot.py
+++ b/agent/application/context/snapshot.py
@@ -47,7 +47,7 @@ def build_context_snapshot(
     if estimated_total is None:
         estimated_total = sum(section["tokens"] for section in sections)
     return {
-        "captured_at": captured_at or datetime.now(timezone.utc).isoformat(),
+        "captured_at": captured_at or datetime.now().astimezone().isoformat(),
         "turn_id": str(turn_id or ""),
         "estimated_total": estimated_total,
         "context_window_tokens": positive_int(

--- a/agent/application/context/snapshot.py
+++ b/agent/application/context/snapshot.py
@@ -1,0 +1,200 @@
+"""Context composition snapshot derived from the real assembly result."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from agent.domain.compaction import (
+    COMPACT_CONTINUATION_USER_CONTENT,
+    COMPACT_HANDOFF_REASONING_CONTENT,
+)
+
+from .estimator import DEFAULT_CONTEXT_WINDOW_TOKENS, ContextEstimator
+from .token_usage import positive_int
+
+
+TOOL_ROW_LIMIT = 5
+RIND_DOC_USER_MARKER = "--- user-doc ---"
+RIND_DOC_PROJECT_MARKER = "--- project-doc ---"
+
+_CONTEXT_KIND_LABELS = {
+    "skill_catalog": "Skill catalog",
+    "goal_policy": "Goal policy",
+    "delegate": "Delegate instruction",
+    "team_agent_catalog": "Team agent catalog",
+    "rind_init": "RIND init",
+}
+
+
+def build_context_snapshot(
+    messages: list[dict],
+    stats: dict,
+    turn_id: str = "",
+    *,
+    captured_at: str | None = None,
+    estimator: ContextEstimator | None = None,
+) -> dict[str, Any]:
+    """Bucket the assembled message list into sections with estimated tokens.
+
+    Pure function: fixed input produces the same sections. The total is taken
+    from the pipeline's own stats (never re-summed), so per-section estimates
+    share the exact per-message payloads the estimator scored at build time.
+    """
+    stats = stats if isinstance(stats, dict) else {}
+    sections = _build_sections(messages, estimator or ContextEstimator())
+    estimated_total = positive_int(stats.get("estimated_input_tokens"))
+    if estimated_total is None:
+        estimated_total = sum(section["tokens"] for section in sections)
+    return {
+        "captured_at": captured_at or datetime.now(timezone.utc).isoformat(),
+        "turn_id": str(turn_id or ""),
+        "estimated_total": estimated_total,
+        "context_window_tokens": positive_int(
+            stats.get("context_window_tokens"),
+            DEFAULT_CONTEXT_WINDOW_TOKENS,
+        ),
+        "sections": sorted(sections, key=lambda section: (-section["tokens"], section["key"])),
+    }
+
+
+def _build_sections(messages: list[dict], estimator: ContextEstimator) -> list[dict[str, Any]]:
+    buckets: dict[str, dict[str, Any]] = {}
+
+    def assign(key: str, label: str, tokens: int) -> None:
+        bucket = buckets.get(key)
+        if bucket is None:
+            bucket = {"key": key, "label": label, "tokens": 0, "messages": 0}
+            buckets[key] = bucket
+        bucket["tokens"] += max(0, int(tokens))
+        bucket["messages"] += 1
+
+    tool_names = _tool_names_by_call_id(messages)
+    top_tools = _top_tool_names(messages, tool_names)
+    for message in messages if isinstance(messages, list) else []:
+        if not isinstance(message, dict):
+            continue
+        kind = message.get("_context_kind")
+        if isinstance(kind, str) and kind.strip():
+            _assign_context_kind(assign, message, kind.strip(), estimator)
+            continue
+        role = message.get("role")
+        if role == "tool":
+            name = tool_names.get(str(message.get("tool_call_id") or "")) or "unknown"
+            if name in top_tools:
+                assign(f"tool:{name}", f"Tool results · {name}", _estimate(estimator, message))
+            else:
+                assign("tool:other", "Tool results · other", _estimate(estimator, message))
+            continue
+        if _is_compaction_handoff(message):
+            assign("compaction_handoff", "Compaction handoff", _estimate(estimator, message))
+            continue
+        if role == "system":
+            assign("system_prompt", "System prompt (incl. capsule)", _estimate(estimator, message))
+        elif role == "user":
+            assign("chat_user", "Chat · user inputs", _estimate(estimator, message))
+        elif role == "assistant":
+            _assign_assistant(assign, message, estimator)
+        else:
+            # Unknown roles form their own bucket under their original name.
+            label = str(role or "unknown")
+            assign(f"role:{label}", label, _estimate(estimator, message))
+    return list(buckets.values())
+
+
+def _assign_context_kind(
+    assign: Callable[[str, str, int], None],
+    message: dict,
+    kind: str,
+    estimator: ContextEstimator,
+) -> None:
+    total = _estimate(estimator, message)
+    if kind == "rind_docs":
+        content = message.get("content")
+        content = content if isinstance(content, str) else ""
+        has_user = RIND_DOC_USER_MARKER in content
+        has_project = RIND_DOC_PROJECT_MARKER in content
+        if has_user and has_project:
+            user_segment = content.split(RIND_DOC_USER_MARKER, 1)[1].split(RIND_DOC_PROJECT_MARKER, 1)[0]
+            user_tokens = min(total, _estimate(estimator, {"role": "system", "content": user_segment}))
+            assign("rind_docs_user", "RIND.md · user", user_tokens)
+            assign("rind_docs_project", "RIND.md · project", total - user_tokens)
+            return
+        if has_user:
+            assign("rind_docs_user", "RIND.md · user", total)
+            return
+        if has_project:
+            assign("rind_docs_project", "RIND.md · project", total)
+            return
+        assign("rind_docs", "RIND.md", total)
+        return
+    # Unknown tags form their own bucket, displayed under their original name.
+    assign(f"kind:{kind}", _CONTEXT_KIND_LABELS.get(kind, kind), total)
+
+
+def _assign_assistant(
+    assign: Callable[[str, str, int], None],
+    message: dict,
+    estimator: ContextEstimator,
+) -> None:
+    total = _estimate(estimator, message)
+    reasoning = message.get("reasoning_content")
+    if isinstance(reasoning, str) and reasoning:
+        reasoning_tokens = min(
+            total,
+            _estimate(estimator, {"role": "assistant", "reasoning_content": reasoning}),
+        )
+        assign("chat_assistant", "Chat · assistant replies", total - reasoning_tokens)
+        assign("reasoning", "Reasoning content", reasoning_tokens)
+        return
+    assign("chat_assistant", "Chat · assistant replies", total)
+
+
+def _is_compaction_handoff(message: dict) -> bool:
+    meta = message.get("meta")
+    if isinstance(meta, dict) and meta.get("kind") == "compact_boundary":
+        return True
+    content = message.get("content")
+    if (
+        message.get("role") == "user"
+        and isinstance(content, str)
+        and content == COMPACT_CONTINUATION_USER_CONTENT
+    ):
+        return True
+    reasoning = message.get("reasoning_content")
+    return (
+        message.get("role") == "assistant"
+        and isinstance(reasoning, str)
+        and reasoning == COMPACT_HANDOFF_REASONING_CONTENT
+    )
+
+
+def _tool_names_by_call_id(messages: list[dict]) -> dict[str, str]:
+    names: dict[str, str] = {}
+    for message in messages if isinstance(messages, list) else []:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        for call in message.get("tool_calls") or []:
+            if not isinstance(call, dict):
+                continue
+            call_id = str(call.get("id") or "")
+            function = call.get("function") if isinstance(call.get("function"), dict) else {}
+            name = str(function.get("name") or "")
+            if call_id and name:
+                names.setdefault(call_id, name)
+    return names
+
+
+def _top_tool_names(messages: list[dict], tool_names: dict[str, str]) -> set[str]:
+    counts: dict[str, int] = {}
+    for message in messages if isinstance(messages, list) else []:
+        if not isinstance(message, dict) or message.get("role") != "tool":
+            continue
+        name = tool_names.get(str(message.get("tool_call_id") or "")) or "unknown"
+        counts[name] = counts.get(name, 0) + 1
+    ranked = sorted(counts, key=lambda name: (-counts[name], name))
+    return set(ranked[:TOOL_ROW_LIMIT])
+
+
+def _estimate(estimator: ContextEstimator, message: dict) -> int:
+    return max(0, int(estimator.estimate_messages([message]).estimated_input_tokens))

--- a/agent/application/context/token_usage.py
+++ b/agent/application/context/token_usage.py
@@ -54,6 +54,35 @@ def normalize_sampling_usage(
     }
 
 
+USAGE_RECORD_FIELDS = (
+    "sampling_kind",
+    "input_tokens",
+    "cached_input_tokens",
+    "cache_hit_rate",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+    "context_window_tokens",
+    "context_usage_percent",
+)
+
+
+def build_usage_record(
+    usage: dict[str, Any],
+    *,
+    session_id: str = "",
+    model: str = "",
+    ts: str | None = None,
+) -> dict[str, Any]:
+    """Shape one normalized sampling into a ledger row: verbatim counting fields plus identity."""
+    source = usage if isinstance(usage, dict) else {}
+    record: dict[str, Any] = {field: source[field] for field in USAGE_RECORD_FIELDS if field in source}
+    record["ts"] = ts or datetime.now(timezone.utc).isoformat()
+    record["session_id"] = str(session_id or "")
+    record["model"] = str(model or "")
+    return record
+
+
 def positive_int(value: Any, default: int | None = None) -> int | None:
     """Parse a positive integer, returning `default` for invalid or non-positive values."""
     try:

--- a/agent/application/context/token_usage.py
+++ b/agent/application/context/token_usage.py
@@ -74,10 +74,13 @@ def build_usage_record(
     model: str = "",
     ts: str | None = None,
 ) -> dict[str, Any]:
-    """Shape one normalized sampling into a ledger row: verbatim counting fields plus identity."""
+    """Shape one normalized sampling into a ledger row: verbatim counting fields plus identity.
+
+    The timestamp carries the local UTC offset so day bucketing follows the
+    user's own calendar, not the server's."""
     source = usage if isinstance(usage, dict) else {}
     record: dict[str, Any] = {field: source[field] for field in USAGE_RECORD_FIELDS if field in source}
-    record["ts"] = ts or datetime.now(timezone.utc).isoformat()
+    record["ts"] = ts or datetime.now().astimezone().isoformat()
     record["session_id"] = str(session_id or "")
     record["model"] = str(model or "")
     return record

--- a/agent/application/context/usage_summary.py
+++ b/agent/application/context/usage_summary.py
@@ -1,0 +1,126 @@
+"""User-level token usage summarization over ledger records."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+
+USAGE_SUMMARY_DEFAULT_DAYS = 7
+USAGE_SUMMARY_MAX_DAYS = 365
+USAGE_SUMMARY_SESSION_LIMIT = 5
+
+
+def summarize_usage(
+    records: list[dict],
+    days: int = USAGE_SUMMARY_DEFAULT_DAYS,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Reduce ledger rows into window totals plus by-day/by-model/session views.
+
+    Pure function: every number traces back to a raw record; nothing is derived
+    beyond grouping and summing.
+    """
+    window_days = _window_days(days)
+    end = _aware(now or datetime.now(timezone.utc))
+    cutoff = end - timedelta(days=window_days)
+
+    totals = {
+        "input": 0,
+        "cached": 0,
+        "output": 0,
+        "reasoning": 0,
+        "total": 0,
+        "samples": 0,
+        "compactions": 0,
+    }
+    by_day: dict[str, int] = {}
+    by_model: dict[str, dict[str, int]] = {}
+    sessions: dict[str, dict[str, Any]] = {}
+
+    for record in records if isinstance(records, list) else []:
+        if not isinstance(record, dict):
+            continue
+        ts = _parse_ts(record.get("ts"))
+        if ts is None or ts < cutoff:
+            continue
+        volume = _record_volume(record)
+        totals["input"] += _non_negative(record.get("input_tokens"))
+        totals["cached"] += _non_negative(record.get("cached_input_tokens"))
+        totals["output"] += _non_negative(record.get("output_tokens"))
+        totals["reasoning"] += _non_negative(record.get("reasoning_output_tokens"))
+        totals["total"] += volume
+        totals["samples"] += 1
+        if record.get("sampling_kind") == "compact":
+            totals["compactions"] += 1
+        day = ts.astimezone(timezone.utc).strftime("%m-%d")
+        by_day[day] = by_day.get(day, 0) + volume
+        model = str(record.get("model") or "unknown")
+        model_bucket = by_model.setdefault(model, {"tokens": 0, "samples": 0})
+        model_bucket["tokens"] += volume
+        model_bucket["samples"] += 1
+        session_id = str(record.get("session_id") or "")
+        if session_id:
+            session = sessions.get(session_id)
+            if session is None:
+                session = sessions[session_id] = {
+                    "session_id": session_id,
+                    "updated_at": ts.isoformat(),
+                    "tokens": 0,
+                    "samples": 0,
+                }
+            session["updated_at"] = max(session["updated_at"], ts.isoformat())
+            session["tokens"] += volume
+            session["samples"] += 1
+
+    return {
+        "days": window_days,
+        "totals": totals,
+        "by_day": [
+            {"day": day, "tokens": by_day[day]}
+            for day in sorted(by_day, reverse=True)
+        ],
+        "by_model": [
+            {"model": model, "tokens": bucket["tokens"], "samples": bucket["samples"]}
+            for model, bucket in sorted(by_model.items(), key=lambda item: (-item[1]["tokens"], item[0]))
+        ],
+        "recent_sessions": sorted(
+            sessions.values(),
+            key=lambda session: (session["updated_at"], session["session_id"]),
+            reverse=True,
+        )[:USAGE_SUMMARY_SESSION_LIMIT],
+    }
+
+
+def _window_days(days: Any) -> int:
+    if isinstance(days, bool) or not isinstance(days, int) or days < 1:
+        return USAGE_SUMMARY_DEFAULT_DAYS
+    return min(days, USAGE_SUMMARY_MAX_DAYS)
+
+
+def _record_volume(record: dict) -> int:
+    total = _non_negative(record.get("total_tokens"))
+    if total > 0:
+        return total
+    return _non_negative(record.get("input_tokens")) + _non_negative(record.get("output_tokens"))
+
+
+def _non_negative(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    return max(0, int(value))
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip())
+    except ValueError:
+        return None
+    return _aware(parsed)
+
+
+def _aware(value: datetime) -> datetime:
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)

--- a/agent/application/context/usage_summary.py
+++ b/agent/application/context/usage_summary.py
@@ -54,7 +54,7 @@ def summarize_usage(
         totals["samples"] += 1
         if record.get("sampling_kind") == "compact":
             totals["compactions"] += 1
-        day = ts.astimezone(timezone.utc).strftime("%m-%d")
+        day = ts.strftime("%m-%d")
         by_day[day] = by_day.get(day, 0) + volume
         model = str(record.get("model") or "unknown")
         model_bucket = by_model.setdefault(model, {"tokens": 0, "samples": 0})
@@ -66,13 +66,19 @@ def summarize_usage(
             if session is None:
                 session = sessions[session_id] = {
                     "session_id": session_id,
+                    "_last": ts,
                     "updated_at": ts.isoformat(),
                     "tokens": 0,
                     "samples": 0,
                 }
-            session["updated_at"] = max(session["updated_at"], ts.isoformat())
+            if ts > session["_last"]:
+                session["_last"] = ts
+                session["updated_at"] = ts.isoformat()
             session["tokens"] += volume
             session["samples"] += 1
+
+    for session in sessions.values():
+        session.pop("_last", None)
 
     return {
         "days": window_days,

--- a/agent/application/ports/session_store.py
+++ b/agent/application/ports/session_store.py
@@ -135,6 +135,10 @@ class SessionStore(Protocol):
         """Persist latest provider token usage for observability."""
         ...
 
+    async def persist_context_breakdown(self, snapshot: dict[str, Any]) -> None:
+        """Persist the latest context composition snapshot for observability."""
+        ...
+
     async def get_latest_sampling_usage(self) -> dict[str, Any] | None:
         """Get the latest provider token usage sample."""
         ...

--- a/agent/bootstrap/container.py
+++ b/agent/bootstrap/container.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Collection
 from dataclasses import dataclass, field
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,7 @@ from agent.infrastructure.config import AppSettings, load_settings
 from agent.infrastructure.llm import OpenAIChatClient, OpenAIClientFactory
 from agent.infrastructure.persistence import JsonlSessionStore
 from agent.infrastructure.persistence import ToolOutputStore
+from agent.infrastructure.persistence.usage_ledger import append_usage_record, default_usage_ledger_path
 from agent.infrastructure.planning import build_plan_snapshot
 from agent.infrastructure.rind_docs import build_rind_doc_context
 from agent.infrastructure.skills import SkillRepository
@@ -215,8 +217,10 @@ def build_agent_container(
         estimator=ContextEstimator(),
         rind_doc_provider=lambda: build_rind_doc_context(workspace_root),
     )
+    usage_recorder = partial(append_usage_record, default_usage_ledger_path())
     compaction_service = shared_resources.compaction_service if shared_resources else CompactionService(
         plan_snapshot_provider=build_plan_snapshot,
+        usage_recorder=usage_recorder,
     )
     turn_runner = TurnRunner(
         chat_client=chat_client,
@@ -226,6 +230,7 @@ def build_agent_container(
         context_manager=context_manager,
         compaction_service=compaction_service,
         skill_repository=skill_repository,
+        usage_recorder=usage_recorder,
     )
     runtime = AgentRuntime(
         turn_runner=turn_runner,

--- a/agent/infrastructure/persistence/jsonl_session_store.py
+++ b/agent/infrastructure/persistence/jsonl_session_store.py
@@ -969,6 +969,17 @@ class JsonlSessionStore(SessionStore):
     async def get_latest_sampling_usage(self) -> dict[str, Any] | None:
         return await asyncio.to_thread(self._latest_meta_usage, "latest_sampling_usage")
 
+    async def persist_context_breakdown(self, snapshot: dict[str, Any]) -> None:
+        """Store the latest context composition snapshot; overwrite = latest, travels with fork."""
+        async with self._write_lock:
+            def _persist():
+                if not self._session_meta or not self._session_paths:
+                    return
+                self._session_meta["latest_context_breakdown"] = dict(snapshot or {})
+                self._persist_meta_sync()
+
+            await asyncio.to_thread(_persist)
+
     async def get_latest_assistant_sampling_usage(self) -> dict[str, Any] | None:
         return await asyncio.to_thread(self._latest_meta_usage, "latest_assistant_sampling_usage")
 

--- a/agent/infrastructure/persistence/usage_ledger.py
+++ b/agent/infrastructure/persistence/usage_ledger.py
@@ -1,0 +1,24 @@
+"""Append-only user-level token usage ledger (~/.rind/usage.jsonl)."""
+
+from __future__ import annotations
+
+import os
+
+from agent.infrastructure.paths import resolve_rind_home
+from agent.infrastructure.persistence.session_files import SessionFiles
+
+
+USAGE_LEDGER_FILENAME = "usage.jsonl"
+
+
+def default_usage_ledger_path() -> str:
+    return str(resolve_rind_home() / USAGE_LEDGER_FILENAME)
+
+
+def append_usage_record(path: str | os.PathLike, record: dict) -> None:
+    """Append one record under the shared file lock; concurrent writers never interleave."""
+    SessionFiles().append_jsonl(str(path), dict(record))
+
+
+def load_usage_records(path: str | os.PathLike) -> list[dict]:
+    return SessionFiles().read_jsonl(str(path))

--- a/agent/runtime/core/turn_runner.py
+++ b/agent/runtime/core/turn_runner.py
@@ -7,10 +7,12 @@ import inspect
 import logging
 import time
 from collections.abc import Callable
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from agent.application.context.compaction import CompactionService
 from agent.application.context.manager import ContextBuildResult, ContextManager
+from agent.application.context.snapshot import build_context_snapshot
+from agent.application.context.token_usage import build_usage_record
 from agent.application.ports.chat_client import ChatClient
 from agent.application.ports.session_store import SessionStore
 from agent.runtime.core.stream_pump import ModelStreamResult, pump_model_stream_events
@@ -71,6 +73,7 @@ class TurnRunner:
         context_manager: ContextManager,
         compaction_service: CompactionService | None = None,
         skill_repository=None,
+        usage_recorder: Callable[[dict], Any] | None = None,
     ):
         self._chat_client = chat_client
         self._tool_processor = tool_processor
@@ -78,6 +81,7 @@ class TurnRunner:
         self._tool_schemas = tool_schemas
         self._context_manager = context_manager
         self._compaction_service = compaction_service or CompactionService()
+        self._usage_recorder = usage_recorder
         self._skill_turn_coordinator = (
             SkillTurnCoordinator(skill_repository) if skill_repository is not None else None
         )
@@ -133,6 +137,7 @@ class TurnRunner:
                     session,
                     transient_system_messages=transient_system_messages,
                     allow_rescue=force_rescue_next_build,
+                    turn_id=turn_id,
                 )
                 force_rescue_next_build = False
                 yield _context_built(context, session, turn_id)
@@ -147,6 +152,7 @@ class TurnRunner:
                         phase_detail=self._compact_phase_detail(sampling_index),
                         transient_system_messages=transient_system_messages,
                         cancellation_token=cancellation_token,
+                        turn_id=turn_id,
                     )
                     yield _context_built(context, session, turn_id)
 
@@ -261,6 +267,7 @@ class TurnRunner:
                                 phase_detail="context_length_recovery",
                                 transient_system_messages=transient_system_messages,
                                 cancellation_token=cancellation_token,
+                                turn_id=turn_id,
                             )
                         else:
                             self._context_manager.reduce_hard_limit(factor=0.8)
@@ -419,6 +426,7 @@ class TurnRunner:
         reason: str = "manual",
         phase: str = "manual",
         cancellation_token: CancellationToken | None = None,
+        turn_id: str = "",
     ) -> dict:
         context = await self._build_context(session)
         compaction_context = await self._compaction_context(session, context)
@@ -434,7 +442,7 @@ class TurnRunner:
             cancellation_token=cancellation_token,
         )
         await self._sync_skill_catalog(session)
-        context = await self._build_context(session)
+        context = await self._build_context(session, turn_id=turn_id)
         self._validate_compact_context(context)
         return record
 
@@ -450,6 +458,7 @@ class TurnRunner:
         phase_detail: str | None = None,
         transient_system_messages: list[dict] | None = None,
         cancellation_token: CancellationToken | None = None,
+        turn_id: str = "",
     ):
         current_context = ContextBuildResult(
             messages=context_messages,
@@ -475,6 +484,7 @@ class TurnRunner:
         context = await self._build_context(
             session,
             transient_system_messages=transient_system_messages,
+            turn_id=turn_id,
         )
         self._validate_compact_context(context)
         return context
@@ -501,16 +511,58 @@ class TurnRunner:
         transient_system_messages: list[dict] | None = None,
         allow_rescue: bool = False,
         include_skill_catalog: bool = True,
+        turn_id: str = "",
     ):
-        return await self._context_manager.build_messages_async(
+        context = await self._context_manager.build_messages_async(
             session=session,
             transient_system_messages=transient_system_messages,
             allow_rescue=allow_rescue,
             include_skill_catalog=include_skill_catalog,
         )
+        if include_skill_catalog:
+            # Only assemblies that feed a model call update the board; the
+            # skill-catalog-free rebuild is the compaction corpus, not a sampling.
+            await self._capture_context_breakdown(session, context, turn_id)
+        return context
+
+    async def _capture_context_breakdown(self, session: SessionStore, context: ContextBuildResult, turn_id: str) -> None:
+        try:
+            messages = context.internal_messages or context.messages
+            snapshot = build_context_snapshot(messages, context.stats, turn_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("Context breakdown capture failed.", exc_info=True)
+            return
+        persist = getattr(session, "persist_context_breakdown", None)
+        if callable(persist):
+            await self._best_effort(persist, snapshot)
 
     async def _persist_sampling_usage(self, session: SessionStore, usage: dict) -> None:
         await self._best_effort(session.persist_sampling_usage, usage)
+        await self._record_usage(session, usage)
+
+    async def _record_usage(self, session: SessionStore, usage: dict) -> None:
+        recorder = self._usage_recorder
+        if recorder is None or not isinstance(usage, dict):
+            return
+        try:
+            record = build_usage_record(
+                usage,
+                session_id=str(getattr(session, "session_id", "") or ""),
+                model=str(getattr(session, "model", "") or ""),
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("Usage record assembly failed.", exc_info=True)
+            return
+        try:
+            await asyncio.to_thread(recorder, record)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("Usage ledger append failed.", exc_info=True)
 
     def _next_steering(self, take_steering: Callable[[], tuple[str, str] | None] | None) -> tuple[str, str] | None:
         if take_steering is None:

--- a/agent/runtime/server/protocol.py
+++ b/agent/runtime/server/protocol.py
@@ -64,6 +64,8 @@ class RuntimeMethod:
     RIND_GOAL_SET = "rind/goal/set"
     RIND_GOAL_STATUS = "rind/goal/status"
     RIND_GOAL_CLEAR = "rind/goal/clear"
+    RIND_CONTEXT_INSPECT = "rind/context/inspect"
+    RIND_USAGE_SUMMARY = "rind/usage/summary"
     SESSION_UPDATE = "session/update"
 
 
@@ -92,6 +94,7 @@ SESSION_SCOPED_METHODS = frozenset(
         RuntimeMethod.RIND_GOAL_SET,
         RuntimeMethod.RIND_GOAL_STATUS,
         RuntimeMethod.RIND_GOAL_CLEAR,
+        RuntimeMethod.RIND_CONTEXT_INSPECT,
     }
 )
 
@@ -131,6 +134,8 @@ CORE_METHODS = (
     RuntimeMethod.RIND_SESSION_COMPACT,
     RuntimeMethod.RIND_COMMAND_EXECUTE,
     RuntimeMethod.RIND_USER_QUESTION_RESPOND,
+    RuntimeMethod.RIND_CONTEXT_INSPECT,
+    RuntimeMethod.RIND_USAGE_SUMMARY,
 )
 
 CAPABILITIES = (
@@ -138,6 +143,7 @@ CAPABILITIES = (
     "models",
     "rind/commands",
     "rind/compaction",
+    "rind/context",
     "rind/user-questions",
     "rind/steering",
     "rind/follow-up",

--- a/agent/runtime/server/stdio.py
+++ b/agent/runtime/server/stdio.py
@@ -1356,13 +1356,15 @@ class WorkerStdioRuntimeServer:
         await self._respond(request, result)
 
     async def _context_inspect(self, request: dict[str, Any]) -> None:
-        """Read the session's latest context breakdown and sampling usage from meta."""
+        """Read the session's latest context breakdown and assistant sampling usage from meta."""
         session_id = await self._required_session_id(request)
         if session_id is None:
             return
         meta = await self._worker.repository.metadata(session_id)
         breakdown = meta.get("latest_context_breakdown")
-        usage = meta.get("latest_sampling_usage")
+        # Assistant samplings describe the context the board shows; a compact
+        # sampling would read the pre-compaction context, so it never anchors.
+        usage = meta.get("latest_assistant_sampling_usage")
         await self._respond(
             request,
             {

--- a/agent/runtime/server/stdio.py
+++ b/agent/runtime/server/stdio.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import inspect
 import json
 import signal
@@ -1087,6 +1088,12 @@ class WorkerStdioRuntimeServer:
             if method == RuntimeMethod.SESSION_FORK:
                 await self._fork_session(request)
                 return
+            if method == RuntimeMethod.RIND_CONTEXT_INSPECT:
+                await self._context_inspect(request)
+                return
+            if method == RuntimeMethod.RIND_USAGE_SUMMARY:
+                await self._usage_summary(request)
+                return
             if method in {RuntimeMethod.SESSION_SUBSCRIBE, RuntimeMethod.SESSION_UNSUBSCRIBE}:
                 await self._subscription_request(request)
                 return
@@ -1347,6 +1354,31 @@ class WorkerStdioRuntimeServer:
             await self._respond_error(request, str(exc), "InvalidRequest")
             return
         await self._respond(request, result)
+
+    async def _context_inspect(self, request: dict[str, Any]) -> None:
+        """Read the session's latest context breakdown and sampling usage from meta."""
+        session_id = await self._required_session_id(request)
+        if session_id is None:
+            return
+        meta = await self._worker.repository.metadata(session_id)
+        breakdown = meta.get("latest_context_breakdown")
+        usage = meta.get("latest_sampling_usage")
+        await self._respond(
+            request,
+            {
+                "session_id": session_id,
+                "breakdown": copy.deepcopy(breakdown) if isinstance(breakdown, dict) else None,
+                "latest_usage": copy.deepcopy(usage) if isinstance(usage, dict) else None,
+            },
+        )
+
+    async def _usage_summary(self, request: dict[str, Any]) -> None:
+        params = request.get("params") if isinstance(request.get("params"), dict) else {}
+        days = params.get("days", 7)
+        if isinstance(days, bool) or not isinstance(days, int) or not 1 <= days <= 365:
+            await self._respond_error(request, "rind/usage/summary days must be an integer from 1 to 365.", "InvalidRequest")
+            return
+        await self._respond(request, await self._worker.usage_summary(days))
 
     async def _subscription_request(self, request: dict[str, Any]) -> None:
         method = str(request.get("method") or "")

--- a/agent/runtime/server/worker.py
+++ b/agent/runtime/server/worker.py
@@ -12,11 +12,14 @@ import tempfile
 import uuid
 from datetime import datetime
 from dataclasses import dataclass, field, replace
+from functools import partial
 from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 from typing import Any
 
 from agent.application.context import CompactionService
+from agent.application.context.token_usage import positive_int
+from agent.application.context.usage_summary import summarize_usage
 from agent.application.tools import ToolResultNormalizer
 from agent.bootstrap import AgentContainer, SharedRuntimeResources, build_agent_container
 from agent.infrastructure.config import AppSettings, validate_settings
@@ -25,6 +28,11 @@ from agent.infrastructure.llm import OpenAIClientFactory, close_async_client
 from agent.infrastructure.persistence import JsonlSessionStore, ToolOutputStore, fork_session
 from agent.infrastructure.persistence.session_files import SessionFiles
 from agent.infrastructure.persistence.session_index_repository import SessionIndexRepository
+from agent.infrastructure.persistence.usage_ledger import (
+    append_usage_record,
+    default_usage_ledger_path,
+    load_usage_records,
+)
 from agent.infrastructure.paths import resolve_session_base, validate_session_id
 from agent.infrastructure.planning import build_plan_snapshot
 from agent.infrastructure.team import discover_agent
@@ -832,10 +840,14 @@ class RuntimeWorker:
         self.session_id = session_id
         self._resume_latest = resume_latest
         tool_output_store = ToolOutputStore(session_dir)
+        usage_recorder = partial(append_usage_record, default_usage_ledger_path())
         self._shared_resources = SharedRuntimeResources(
             tool_result_normalizer=ToolResultNormalizer(),
             stream_parser=MessageStreamParser(),
-            compaction_service=CompactionService(plan_snapshot_provider=build_plan_snapshot),
+            compaction_service=CompactionService(
+                plan_snapshot_provider=build_plan_snapshot,
+                usage_recorder=usage_recorder,
+            ),
             tool_output_store=tool_output_store,
         )
         self.repository = SessionRepository(session_dir=session_dir)
@@ -894,6 +906,12 @@ class RuntimeWorker:
     async def fork_session(self, session_id: str, before_message_id: str | None = None) -> dict[str, Any]:
         clean = validate_session_id(session_id)
         return await self.repository.fork(clean, before_message_id)
+
+    async def usage_summary(self, days: int = 7) -> dict[str, Any]:
+        """Summarize the user-level usage ledger; every number traces to a raw row."""
+        window = max(1, min(positive_int(days, 7), 365))
+        records = await asyncio.to_thread(load_usage_records, default_usage_ledger_path())
+        return summarize_usage(records, window)
 
     async def close(self) -> None:
         await self.execution.close()

--- a/frontend-cli/lib/cli-input-actions.js
+++ b/frontend-cli/lib/cli-input-actions.js
@@ -273,6 +273,10 @@ export function createCliInputActions({
       handleForkInput(session, event);
       return;
     }
+    if (session.mode === "context-board") {
+      handleContextBoardInput(session, event);
+      return;
+    }
     const key = event;
     const matches = session.menuState ? syncSlashMenu(session) : [];
     const menuKey = !key.ctrl && !key.alt && !key.shift && ["escape", "up", "down"].includes(key.name);
@@ -312,7 +316,7 @@ export function createCliInputActions({
       return;
     }
     const session = state.input.session;
-    if (!session || session.mode === "model" || session.mode === "theme" || session.mode === "sessions" || session.mode === "fork") {
+    if (!session || session.mode === "model" || session.mode === "theme" || session.mode === "sessions" || session.mode === "fork" || session.mode === "context-board") {
       return;
     }
     if (session.mode === "question" && !session.questionState.isEditing()) {
@@ -563,6 +567,28 @@ export function createCliInputActions({
     if (!modified && session.choiceState.handleKey(key)) output.redraw();
   }
 
+  function askContextBoard(board) {
+    return new Promise((resolve) => {
+      const session = { mode: "context-board", inputText: "/context", board, pageIndex: 0, resolve };
+      state.input.session = session;
+      state.input.active = true;
+      cancelActiveInput = () => completeTtyInput(session, "", false);
+      output.redraw(true);
+    });
+  }
+
+  function handleContextBoardInput(session, key) {
+    const modified = key.ctrl || key.alt || key.shift;
+    if (!modified && key.name === "escape") {
+      completeTtyInput(session, "", false);
+      return;
+    }
+    if (!modified && (key.name === "tab" || key.name === "left" || key.name === "right")) {
+      session.pageIndex = (session.pageIndex + 1) % 2;
+      output.redraw();
+    }
+  }
+
   function askForkPointMenu(items) {
     return new Promise((resolve) => {
       const choiceState = createChoiceMenuState(items.map((item) => item.label), items[0].label);
@@ -605,6 +631,7 @@ export function createCliInputActions({
     askSessionMenu,
     askTeamBlueprint,
     askForkPointMenu,
+    askContextBoard,
     cancel: () => cancelActiveInput?.(),
   };
 }

--- a/frontend-cli/lib/cli-runtime-controller.js
+++ b/frontend-cli/lib/cli-runtime-controller.js
@@ -1,5 +1,5 @@
 import { REASONING_EFFORTS } from "./runtime-protocol.js";
-import { modelListErrorText, commandResultText, goalCommandText, sessionSwitchedText } from "./rendering.js";
+import { commandResultText, contextBoardText, goalCommandText, modelListErrorText, sessionSwitchedText, usageBoardText } from "./rendering.js";
 
 export function createCliRuntimeController({
   client,
@@ -15,6 +15,7 @@ export function createCliRuntimeController({
   askEffortMenu = null,
   askSessionMenu,
   askForkPointMenu,
+  askContextBoard = null,
   restoreLiveTurn,
   renderHistory = () => {},
   clearPendingInputs,
@@ -281,6 +282,63 @@ export function createCliRuntimeController({
     }
   }
 
+  async function runContextBoard() {
+    if (state.turn.active || state.display.activeCompact) {
+      log("Cannot open the context board while a turn is running. Wait for it to finish or stop it first.");
+      return;
+    }
+    let data;
+    try {
+      data = await fetchContextBoardData();
+    } catch (error) {
+      log(`Context board failed: ${error instanceof Error ? error.message : String(error)}`);
+      return;
+    }
+    if (!askContextBoard) {
+      printContextPages(data);
+      return;
+    }
+    await askContextBoard({
+      render: (pageIndex, width) => contextPageText(data, pageIndex, width),
+    });
+  }
+
+  async function printContextReport() {
+    let data;
+    try {
+      data = await fetchContextBoardData();
+    } catch (error) {
+      log(`Context report failed: ${error instanceof Error ? error.message : String(error)}`);
+      return;
+    }
+    printContextPages(data);
+  }
+
+  async function fetchContextBoardData() {
+    const breakdownResult = await request(methods.contextInspect);
+    const summaryResult = await request(methods.usageSummary, { days: CONTEXT_BOARD_DAYS });
+    return {
+      breakdown: breakdownResult?.breakdown && typeof breakdownResult.breakdown === "object" ? breakdownResult.breakdown : null,
+      latestUsage: breakdownResult?.latest_usage && typeof breakdownResult.latest_usage === "object" ? breakdownResult.latest_usage : null,
+      summary: summaryResult && typeof summaryResult === "object" ? summaryResult : null,
+    };
+  }
+
+  function contextPageText(data, pageIndex, width, { plain = false } = {}) {
+    return pageIndex === 0
+      ? contextBoardText({ breakdown: data.breakdown, latest_usage: data.latestUsage, index: 1, count: 2, plain }, width)
+      : usageBoardText({ summary: data.summary, index: 2, count: 2, plain }, width);
+  }
+
+  function printContextPages(data) {
+    for (const pageIndex of [0, 1]) {
+      const text = contextPageText(data, pageIndex, process.stdout.columns || 0, { plain: true });
+      if (text.trim()) {
+        log(text);
+      }
+    }
+  }
+
   function startCompactCommand() {
     if (state.display.activeCompact) {
       log("Compact is already running.");
@@ -374,11 +432,15 @@ export function createCliRuntimeController({
     refreshGoalState,
     runSessionsSelector,
     runForkSelector,
+    runContextBoard,
+    printContextReport,
     startCompactCommand,
     runModelSelector,
     runEffortCommand,
   };
 }
+
+const CONTEXT_BOARD_DAYS = 7;
 
 function mergeSlashCommands(...groups) {
   const byName = new Map();

--- a/frontend-cli/lib/command-controller.js
+++ b/frontend-cli/lib/command-controller.js
@@ -74,6 +74,16 @@ export function createCommandController({
       }
       return;
     }
+    if (isBareContextCommand(text)) {
+      if (input.isTerminal && input.runContextBoard) {
+        await input.runContextBoard();
+      } else if (input.printContextReport) {
+        await input.printContextReport();
+      } else {
+        output.log?.("/context requires a connected runtime.");
+      }
+      return;
+    }
     const result = await request(runtimeMethods.commandExecute, { input: text });
     await applyResult(result);
   }
@@ -164,6 +174,10 @@ function isBareSessionsCommand(value) {
 
 function isBareForkCommand(value) {
   return String(value || "").trim().toLowerCase() === "/fork";
+}
+
+function isBareContextCommand(value) {
+  return String(value || "").trim().toLowerCase() === "/context";
 }
 
 function isCompactCommand(value) {

--- a/frontend-cli/lib/command-controller.js
+++ b/frontend-cli/lib/command-controller.js
@@ -74,7 +74,11 @@ export function createCommandController({
       }
       return;
     }
-    if (isBareContextCommand(text)) {
+    if (isContextCommand(text)) {
+      const argument = contextArgument(text);
+      if (argument) {
+        output.log?.("Custom ranges are not supported yet; showing the last 7 days.");
+      }
       if (input.isTerminal && input.runContextBoard) {
         await input.runContextBoard();
       } else if (input.printContextReport) {
@@ -176,8 +180,12 @@ function isBareForkCommand(value) {
   return String(value || "").trim().toLowerCase() === "/fork";
 }
 
-function isBareContextCommand(value) {
-  return String(value || "").trim().toLowerCase() === "/context";
+function isContextCommand(value) {
+  return /^\/context\b/i.test(String(value || "").trim());
+}
+
+function contextArgument(value) {
+  return String(value || "").trim().replace(/^\/context\b/i, "").trim();
 }
 
 function isCompactCommand(value) {

--- a/frontend-cli/lib/frontend-cli-implementation.js
+++ b/frontend-cli/lib/frontend-cli-implementation.js
@@ -220,6 +220,7 @@ const runtimeController = createCliRuntimeController({
   askSessionMenu: (...args) => inputActions.askSessionMenu(...args),
   askForkPointMenu: (...args) => inputActions.askForkPointMenu(...args),
   askTeamBlueprint: (...args) => inputActions.askTeamBlueprint(...args),
+  askContextBoard: (...args) => inputActions.askContextBoard(...args),
   restoreLiveTurn,
   renderHistory,
   clearPendingInputs: (...args) => inputActions.clearPendingInputs(...args),
@@ -264,6 +265,8 @@ commandController = createCommandController({
     startCompactCommand: runtimeController.startCompactCommand,
     runSessionsSelector: runtimeController.runSessionsSelector,
     runForkSelector: runtimeController.runForkSelector,
+    runContextBoard: runtimeController.runContextBoard,
+    printContextReport: runtimeController.printContextReport,
     runLocalCommand: async (text) => {
       if (!Object.keys(sessionState.settings).length) {
         sessionState.settings = await loadLocalSettings(undefined, sessionState.info.workspace_root || sessionState.info.cwd || process.cwd());
@@ -569,6 +572,17 @@ function composeFrame(width = process.stdout.columns || 80) {
       inputText: session.inputText,
       cursor: { line: 0, column: session.inputText.length },
       menuText: sessionMenuText(session.choiceState.options(), session.choiceState.selectedIndex()).trimEnd(),
+    };
+  }
+  if (session.mode === "context-board") {
+    return {
+      showCaret: false,
+      prompt: "",
+      inputText: "",
+      cursor: { line: 0, column: 0 },
+      menuText: typeof session.board?.render === "function"
+        ? session.board.render(session.pageIndex, width)
+        : "",
     };
   }
   const matches = session.menuState

--- a/frontend-cli/lib/local-slash-commands.js
+++ b/frontend-cli/lib/local-slash-commands.js
@@ -6,6 +6,7 @@ import { currentTheme, setTheme, themeNames, themeOptions } from "./theme.js";
 export const LOCAL_SLASH_COMMANDS = Object.freeze([
   { name: "compact", description: "Compact current session context", usage: "/compact" },
   { name: "config", description: "Show config guidance", usage: "/config" },
+  { name: "context", description: "Show context composition and token usage", usage: "/context" },
   { name: "doctor", description: "Run local setup diagnostics", usage: "/doctor" },
   { name: "effort", description: "Show or change reasoning effort", usage: "/effort [low | medium | high | xhigh | max]" },
   { name: "fork", description: "Fork the current session", usage: "/fork" },

--- a/frontend-cli/lib/rendering.js
+++ b/frontend-cli/lib/rendering.js
@@ -146,7 +146,7 @@ function contextMetaLines(windowTokens, usedPercent, measured, estimated, inner)
   const paintTone = tone === "err" ? red : tone === "warn" ? paint.warning : (text) => text;
   const windowPart = `Window ${formatBoardNumber(windowTokens)} · ${paintTone(`used ${Math.round(usedPercent * 100)}%`)}`;
   const measuredPart = measured > 0
-    ? `measured ${formatBoardNumber(measured)} · estimated ${formatBoardNumber(estimated)} ${estimatedDeviation(measured, estimated)}`
+    ? `measured ${formatBoardNumber(measured)} · estimated ~${formatBoardNumber(estimated)} ${estimatedDeviation(measured, estimated)}`
     : "";
   if (measuredPart && textWidth(`${windowPart}   ${measuredPart}`) > inner) {
     return [windowPart, measuredPart];
@@ -367,8 +367,8 @@ export function startupText(info = {}, width) {
   return sections.filter(Boolean).join("\n\n");
 }
 
-export function promptText(info = {}, _stats = {}, state = {}, frameWidth) {
-  return inputPromptFrame(promptHeaderLine(info, frameWidth), state, frameWidth);
+export function promptText(info = {}, stats = {}, state = {}, frameWidth) {
+  return inputPromptFrame(promptHeaderLine(info, stats, frameWidth), state, frameWidth);
 }
 
 export function promptActivityLine(state = {}) {
@@ -1602,7 +1602,7 @@ function visibleLength(text) {
   return textWidth(text);
 }
 
-function promptHeaderLine(info, frameWidth) {
+function promptHeaderLine(info, stats = {}, frameWidth) {
   const backgroundCount = Number(info.background_count);
   const delegateCount = Number(info.delegate_count);
   const taskHints = [];
@@ -1615,6 +1615,7 @@ function promptHeaderLine(info, frameWidth) {
   const taskHint = taskHints.length
     ? dim(` · ${taskHints.join(" ")} (ctrl+b monitor)`)
     : "";
+  const ctxSegment = contextUsageSegment(stats);
   const model = singleLine(info.model);
   const effort = singleLine(info.reasoning_effort);
   const cwd = middleClip(info.cwd, 56);
@@ -1622,15 +1623,25 @@ function promptHeaderLine(info, frameWidth) {
   const effortSegment = effort ? `${dim(" · ")}${promptModel(effort)}` : "";
   if (model && cwd) {
     const separator = " · ";
-    const pathWidth = width - visibleLength(model) - visibleLength(separator) - visibleLength(taskHint) - visibleLength(effortSegment);
+    const pathWidth = width - visibleLength(model) - visibleLength(separator) - visibleLength(taskHint) - visibleLength(effortSegment) - visibleLength(ctxSegment);
     if (pathWidth > 0) {
-      return `  ${promptModel(clipSingleLine(model, width))}${effortSegment}${dim(separator)}${promptPath(clipSingleLine(cwd, pathWidth))}${taskHint}`;
+      return `  ${promptModel(clipSingleLine(model, width))}${effortSegment}${dim(separator)}${promptPath(clipSingleLine(cwd, pathWidth))}${taskHint}${ctxSegment}`;
     }
   }
   if (model) {
-    return `  ${promptModel(clipSingleLine(model, width))}${taskHint}`;
+    return `  ${promptModel(clipSingleLine(model, width))}${taskHint}${ctxSegment}`;
   }
-  return cwd ? `  ${promptPath(clipSingleLine(cwd, width))}${taskHint}` : "";
+  return cwd ? `  ${promptPath(clipSingleLine(cwd, width))}${taskHint}${ctxSegment}` : "";
+}
+
+function contextUsageSegment(stats) {
+  const ratio = Number(stats.context_usage_percent);
+  if (!Number.isFinite(ratio) || ratio <= 0) {
+    return "";
+  }
+  const percent = `ctx ${Math.round(ratio * 100)}%`;
+  const tone = occupancyTone(ratio);
+  return `${dim(" · ")}${tone === "err" ? red(percent) : tone === "warn" ? paint.warning(percent) : percent}`;
 }
 
 function composerWidth(frameWidth) {

--- a/frontend-cli/lib/rendering.js
+++ b/frontend-cli/lib/rendering.js
@@ -1,4 +1,4 @@
-import { clipCells, graphemes, middleClipCells, textWidth, wrapTextCells } from "./text-width.js";
+import { clipCells, graphemes, middleClipCells, stripAnsi, textWidth, wrapTextCells } from "./text-width.js";
 import { formatDuration } from "./tool-display.js";
 import { paint, flavorSwatch } from "./theme.js";
 import { homedir } from "node:os";
@@ -6,6 +6,358 @@ import { homedir } from "node:os";
 const MAX_STARTUP_BANNER_WIDTH = 80;
 const MAX_COMPOSER_WIDTH = 78;
 const MAX_FILE_CHANGE_LINES = 20;
+const BOARD_MIN_WIDTH = 60;
+const BOARD_MAX_WIDTH = 100;
+const BOARD_PALETTE_ROLES = ["accent", "success", "warning", "danger", "notice", "path", "code", "fence"];
+const BOARD_SECTION_SHORT_LABELS = {
+  chat_user: "user",
+  chat_assistant: "chat",
+  reasoning: "reasoning",
+  system_prompt: "system",
+  skill_catalog: "skills",
+  rind_docs: "RIND",
+  rind_docs_user: "RIND",
+  rind_docs_project: "RIND",
+  compaction_handoff: "compact",
+  goal_policy: "goal",
+  delegate: "delegate",
+  team_agent_catalog: "team",
+  "tool:other": "other",
+};
+
+export function boardWidth(width) {
+  const columns = Number(width ?? process.stdout.columns);
+  if (!Number.isFinite(columns) || columns <= 0) {
+    return BOARD_MAX_WIDTH;
+  }
+  return Math.max(BOARD_MIN_WIDTH, Math.min(BOARD_MAX_WIDTH, Math.floor(columns)));
+}
+
+export function occupancyTone(percent) {
+  const value = Number(percent);
+  if (!Number.isFinite(value)) {
+    return "neutral";
+  }
+  if (value > 0.85) {
+    return "err";
+  }
+  if (value >= 0.6) {
+    return "warn";
+  }
+  return "neutral";
+}
+
+const BOARD_FOOTER = "Tab switch page · Esc exit";
+
+export function contextBoardText(page = {}, width) {
+  const frameWidth = boardWidth(width);
+  const breakdown = isBoardRecord(page.breakdown) ? page.breakdown : null;
+  const usage = isBoardRecord(page.latest_usage) ? page.latest_usage : null;
+  const plain = page.plain === true;
+  const title = "Context · last sampling";
+  if (!breakdown || !Array.isArray(breakdown.sections) || !breakdown.sections.length) {
+    return boardPanel({
+      title,
+      lines: boardEmptyLines(frameWidth, "No context sampled yet"),
+      footer: BOARD_FOOTER,
+      page,
+      frameWidth,
+      plain,
+    });
+  }
+  const windowTokens = boardNumber(breakdown.context_window_tokens);
+  const estimated = boardNumber(breakdown.estimated_total);
+  const measured = Math.max(0, boardNumber(usage?.input_tokens));
+  const usedPercent = windowTokens > 0 ? estimated / windowTokens : 0;
+  const lines = contextMetaLines(windowTokens, usedPercent, measured, estimated, frameWidth - 4);
+  const innerWidth = frameWidth - 4;
+  if (windowTokens > 0) {
+    lines.push(stackedShareBar(breakdown.sections, windowTokens, innerWidth));
+    lines.push(barUnderline(breakdown.sections, windowTokens, innerWidth));
+  }
+  lines.push(...contextSectionRows(breakdown.sections, estimated, innerWidth));
+  return boardPanel({
+    title: contextTitle(breakdown, title),
+    lines,
+    footer: BOARD_FOOTER,
+    page,
+    frameWidth,
+    plain,
+  });
+}
+
+export function usageBoardText(page = {}, width) {
+  const frameWidth = boardWidth(width);
+  const summary = isBoardRecord(page.summary) ? page.summary : {};
+  const totals = isBoardRecord(summary.totals) ? summary.totals : {};
+  const plain = page.plain === true;
+  const days = boardNumber(summary.days) || 7;
+  const title = `Token usage · last ${days} day${days === 1 ? "" : "s"}`;
+  if (!boardNumber(totals.samples)) {
+    return boardPanel({
+      title,
+      lines: boardEmptyLines(frameWidth, "No usage recorded yet"),
+      footer: BOARD_FOOTER,
+      page,
+      frameWidth,
+      plain,
+    });
+  }
+  const lines = usageHeroLines(totals, frameWidth - 4);
+  lines.push(dim(`${boardNumber(totals.samples)} samples`));
+  const byDay = Array.isArray(summary.by_day) ? summary.by_day : [];
+  if (byDay.length) {
+    lines.push("", bold("By day"), ...byDayRows(byDay, frameWidth - 4));
+  }
+  const byModel = Array.isArray(summary.by_model) ? summary.by_model : [];
+  if (byModel.length) {
+    lines.push("", bold("By model"), ...rightRows(byModel.map((row) => [boardText(row?.model), boardCompact(row?.tokens)]), frameWidth - 4));
+  }
+  const sessions = Array.isArray(summary.recent_sessions) ? summary.recent_sessions : [];
+  if (sessions.length) {
+    lines.push(
+      "",
+      bold(`By session (latest ${sessions.length})`),
+      ...rightRows(sessions.map((row) => [sessionRowLabel(row), boardCompact(row?.tokens)]), frameWidth - 4),
+    );
+  }
+  const compactions = boardNumber(totals.compactions);
+  const footer = compactions > 0
+    ? `${formatBoardNumber(compactions)} compaction call${compactions === 1 ? "" : "s"} · ${BOARD_FOOTER}`
+    : BOARD_FOOTER;
+  return boardPanel({ title, lines, footer, page, frameWidth, plain });
+}
+
+function contextTitle(breakdown, fallback) {
+  const turn = boardText(breakdown.turn_id);
+  const time = boardText(breakdown.captured_at).slice(11, 19);
+  const parts = [fallback];
+  if (turn) {
+    parts.push(`turn ${turn.slice(0, 4)}`);
+  }
+  if (/^\d{2}:\d{2}:\d{2}$/.test(time)) {
+    parts.push(time);
+  }
+  return parts.join(" · ");
+}
+
+function contextMetaLines(windowTokens, usedPercent, measured, estimated, inner) {
+  const tone = occupancyTone(usedPercent);
+  const paintTone = tone === "err" ? red : tone === "warn" ? paint.warning : (text) => text;
+  const windowPart = `Window ${formatBoardNumber(windowTokens)} · ${paintTone(`used ${Math.round(usedPercent * 100)}%`)}`;
+  const measuredPart = measured > 0
+    ? `measured ${formatBoardNumber(measured)} · estimated ${formatBoardNumber(estimated)} ${estimatedDeviation(measured, estimated)}`
+    : "";
+  if (measuredPart && textWidth(`${windowPart}   ${measuredPart}`) > inner) {
+    return [windowPart, measuredPart];
+  }
+  return [measuredPart ? `${windowPart}   ${measuredPart}` : windowPart];
+}
+
+function estimatedDeviation(measured, estimated) {
+  if (estimated <= 0) {
+    return "";
+  }
+  const percent = Math.round(((measured - estimated) / estimated) * 100);
+  return `(${percent >= 0 ? "+" : ""}${percent}%)`;
+}
+
+function stackedShareBar(sections, windowTokens, cells) {
+  const spans = boardSpans(sections, windowTokens, cells);
+  const remaining = Math.max(0, cells - spans.reduce((sum, span) => sum + span.cells, 0));
+  const bar = spans.map((span, index) => (
+    boardPalette(index)(BOARD_BAR_CELL.repeat(span.cells))
+  )).join("");
+  return `${bar}${dim(BOARD_REMAINDER_CELL.repeat(remaining))}`;
+}
+
+function barUnderline(sections, windowTokens, cells) {
+  const spans = boardSpans(sections, windowTokens, cells);
+  const pieces = [];
+  for (const [index, span] of spans.entries()) {
+    const label = boardShortLabel(span);
+    const labelWidth = textWidth(label);
+    if (label && span.cells >= labelWidth + 1) {
+      pieces.push(boardPalette(index)(label));
+      pieces.push(dim(BOARD_UNDERLINE_CELL.repeat(span.cells - labelWidth)));
+    } else {
+      pieces.push(dim(BOARD_UNDERLINE_CELL.repeat(span.cells)));
+    }
+  }
+  pieces.push(dim(BOARD_UNDERLINE_CELL.repeat(Math.max(0, cells - spans.reduce((sum, span) => sum + span.cells, 0)))));
+  return pieces.join("");
+}
+
+function boardSpans(sections, windowTokens, cells) {
+  return sections.map((section, index) => ({
+    ...section,
+    paletteIndex: index,
+    cells: Math.max(0, Math.round((boardNumber(section.tokens) / windowTokens) * cells)),
+  }));
+}
+
+function contextSectionRows(sections, total, innerWidth) {
+  const nameWidth = Math.min(
+    Math.max(12, ...sections.map((section) => textWidth(boardText(section.label)))),
+    Math.max(12, innerWidth - 24),
+  );
+  const tokenTexts = sections.map((section) => formatBoardNumber(section.tokens));
+  const tokenWidth = Math.max(6, ...tokenTexts.map(textWidth));
+  const messageTexts = sections.map((section) => boardMessagesLabel(section.messages));
+  const messageWidth = Math.max(6, ...messageTexts.map(textWidth));
+  return sections.map((section, index) => {
+    const percent = total > 0 ? Math.round((boardNumber(section.tokens) / total) * 100) : 0;
+    return [
+      `  ${padRight(clipSingleLine(section.label, nameWidth), nameWidth)}`,
+      padLeft(tokenTexts[index], tokenWidth),
+      padLeft(`${percent}%`, 4),
+      padLeft(messageTexts[index], messageWidth),
+    ].join("  ");
+  });
+}
+
+function boardMessagesLabel(count) {
+  const value = Math.max(0, boardNumber(count));
+  return `${formatBoardNumber(value)} ${value === 1 ? "msg" : "msgs"}`;
+}
+
+function usageHeroLine(totals) {
+  const input = Math.max(0, boardNumber(totals.input));
+  const cached = Math.max(0, boardNumber(totals.cached));
+  const hit = input > 0 ? Math.round((cached / input) * 100) : 0;
+  return [
+    `Input ${boardCompact(totals.input)}`,
+    `Cache hit ${boardCompact(cached)}·${hit}%`,
+    `Output ${boardCompact(totals.output)}`,
+    `Reasoning ${boardCompact(totals.reasoning)}`,
+  ].join("   ");
+}
+
+function usageHeroLines(totals, inner) {
+  const line = usageHeroLine(totals);
+  if (textWidth(stripAnsi(line)) <= inner) {
+    return [line];
+  }
+  return [
+    `Input ${boardCompact(totals.input)}   Cache hit ${boardCompact(totals.cached)}`,
+    `Output ${boardCompact(totals.output)}   Reasoning ${boardCompact(totals.reasoning)}`,
+  ];
+}
+
+function byDayRows(byDay, innerWidth) {
+  const values = byDay.map((row) => boardCompact(row?.tokens));
+  const valueWidth = Math.max(5, ...values.map(textWidth));
+  const peak = Math.max(1, ...byDay.map((row) => Math.max(0, boardNumber(row?.tokens))));
+  const barCells = Math.max(3, innerWidth - 11 - valueWidth);
+  return byDay.map((row, index) => {
+    const filled = Math.max(row && boardNumber(row.tokens) > 0 ? 1 : 0, Math.round((Math.max(0, boardNumber(row?.tokens)) / peak) * barCells));
+    const bar = accent(BOARD_BAR_CELL.repeat(Math.min(barCells, filled)));
+    const region = bar + " ".repeat(Math.max(0, barCells - Math.min(barCells, filled)));
+    return `  ${boardDayLabel(row?.day)}  ${region}  ${padLeft(values[index], valueWidth)}`;
+  });
+}
+
+function boardDayLabel(day) {
+  const text = boardText(day);
+  return /^\d{2}-\d{2}$/.test(text) ? text : " ".repeat(5);
+}
+
+function rightRows(rows, innerWidth) {
+  const valueWidth = Math.max(5, ...rows.map((row) => textWidth(row[1])));
+  const labelWidth = Math.max(1, innerWidth - 2 - valueWidth - 2);
+  const clipped = rows.map((row) => clipSingleLine(row[0], labelWidth));
+  const columnWidth = Math.max(1, ...clipped.map(textWidth));
+  return rows.map((row, index) => `  ${padRight(clipped[index], columnWidth)}  ${padLeft(row[1], valueWidth)}`);
+}
+
+function sessionRowLabel(row) {
+  const updated = boardText(row?.updated_at);
+  const day = /^\d{4}-\d{2}-\d{2}/.test(updated) ? updated.slice(5, 10) : "";
+  return [day, boardText(row?.session_id)].filter(Boolean).join(" ");
+}
+
+function boardShortLabel(section) {
+  if (BOARD_SECTION_SHORT_LABELS[section.key]) {
+    return BOARD_SECTION_SHORT_LABELS[section.key];
+  }
+  if (String(section.key || "").startsWith("tool:")) {
+    return String(section.key).slice(5);
+  }
+  const label = boardText(section.label);
+  return label.split("·")[0].trim().slice(0, 12);
+}
+
+function boardPalette(index) {
+  const painter = paint[BOARD_PALETTE_ROLES[index % BOARD_PALETTE_ROLES.length]];
+  return typeof painter === "function" ? painter : (text) => text;
+}
+
+function boardPanel({ title, lines, footer, page, frameWidth, plain }) {
+  const index = Math.max(1, boardNumber(page?.index) || 1);
+  const count = Math.max(index, boardNumber(page?.count) || 1);
+  if (plain) {
+    // Interaction hints are meaningless in frame-less pipe output.
+    return [bold(clipSingleLine(title, frameWidth)), ...lines].join("\n");
+  }
+  const inner = frameWidth - 4;
+  const pageLabel = count > 1 ? `${index}/${count}` : "";
+  const titlePart = ` ${clipSingleLine(title, inner - pageLabel.length - 4)} `;
+  const dashes = Math.max(1, frameWidth - 2 - textWidth(titlePart) - (pageLabel ? pageLabel.length + 2 : 0));
+  const top = `┌${accent(titlePart)}${dim("─".repeat(dashes))}${pageLabel ? ` ${dim(pageLabel)} ` : ""}┐`;
+  const footerLines = footer ? [dim(footer)] : [];
+  const bodyRows = [...lines, ...footerLines].map((line) => `${dim("│")} ${padRight(line, inner)} ${dim("│")}`);
+  const bottom = `${dim("└")}${dim("─".repeat(frameWidth - 2))}${dim("┘")}`;
+  return [top, ...bodyRows, bottom].join("\n");
+}
+
+function boardEmptyLines(frameWidth, label) {
+  const inner = frameWidth - 4;
+  return [
+    boardCentered(bold(label || "Nothing sampled yet"), inner),
+    boardCentered(dim("Send a message first, then try again."), inner),
+  ];
+}
+
+function boardCentered(text, inner) {
+  return `${" ".repeat(Math.max(0, Math.floor((inner - textWidth(text)) / 2)))}${text}`;
+}
+
+function isBoardRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function boardText(value) {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function boardNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function formatBoardNumber(value) {
+  const number = Math.max(0, Math.round(boardNumber(value)));
+  return String(number).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+function boardCompact(value) {
+  const number = Math.max(0, boardNumber(value));
+  if (number >= 1e6) {
+    return `${(number / 1e6).toFixed(2)}M`;
+  }
+  if (number >= 1e5) {
+    return `${Math.round(number / 1e3)}K`;
+  }
+  if (number >= 1e3) {
+    return `${(number / 1e3).toFixed(1)}K`.replace(/\.0K$/, "K");
+  }
+  return String(Math.round(number));
+}
+
+const BOARD_BAR_CELL = "█";
+const BOARD_REMAINDER_CELL = "░";
+const BOARD_UNDERLINE_CELL = "▔";
+
 
 export function startupText(info = {}, width) {
   const header = startupBannerText(info, width);
@@ -1240,6 +1592,10 @@ function activityFrame(frame) {
 
 function padRight(text, width) {
   return `${text}${" ".repeat(Math.max(0, width - visibleLength(text)))}`;
+}
+
+function padLeft(text, width) {
+  return `${" ".repeat(Math.max(0, width - visibleLength(text)))}${text}`;
 }
 
 function visibleLength(text) {

--- a/frontend-cli/lib/runtime-protocol.js
+++ b/frontend-cli/lib/runtime-protocol.js
@@ -29,6 +29,8 @@ export const runtimeMethods = Object.freeze({
   goalSet: "rind/goal/set",
   goalStatus: "rind/goal/status",
   goalClear: "rind/goal/clear",
+  contextInspect: "rind/context/inspect",
+  usageSummary: "rind/usage/summary",
 });
 
 export const sessionScopedMethods = new Set([
@@ -53,6 +55,7 @@ export const sessionScopedMethods = new Set([
   runtimeMethods.goalSet,
   runtimeMethods.goalStatus,
   runtimeMethods.goalClear,
+  runtimeMethods.contextInspect,
 ]);
 
 export const turnScopedMethods = new Set([

--- a/frontend-cli/test/command-controller.test.js
+++ b/frontend-cli/test/command-controller.test.js
@@ -209,6 +209,7 @@ test("local command catalog stays complete before the runtime starts", async () 
     "quit",
     "compact",
     "config",
+    "context",
     "doctor",
     "effort",
     "fork",

--- a/frontend-cli/test/context-board.test.js
+++ b/frontend-cli/test/context-board.test.js
@@ -12,7 +12,7 @@ import { createTui } from "../lib/tui/tui.js";
 import { Container } from "../lib/tui/component.js";
 import { ComposerArea } from "../lib/components/composer-area.js";
 import { MonitorStack } from "../lib/components/monitor-stack.js";
-import { contextBoardText, occupancyTone, usageBoardText } from "../lib/rendering.js";
+import { contextBoardText, occupancyTone, promptText, usageBoardText } from "../lib/rendering.js";
 import { resetTheme, setTheme, flavorSwatch } from "../lib/theme.js";
 import { stripAnsi, textWidth } from "../lib/text-width.js";
 
@@ -22,14 +22,14 @@ const BREAKDOWN = {
   estimated_total: 41320,
   context_window_tokens: 131072,
   sections: [
-    { key: "tool:bash", label: "Tool results · bash", tokens: 14200, messages: 3 },
     { key: "system_prompt", label: "System prompt (incl. capsule)", tokens: 12400, messages: 1 },
-    { key: "chat_assistant", label: "Chat · assistant replies", tokens: 7300, messages: 6 },
     { key: "rind_docs_project", label: "RIND.md · project", tokens: 2100, messages: 1 },
-    { key: "chat_user", label: "Chat · user inputs", tokens: 1900, messages: 4 },
-    { key: "tool:other", label: "Tool results · other", tokens: 1780, messages: 2 },
-    { key: "reasoning", label: "Reasoning content", tokens: 1200, messages: 6 },
     { key: "skill_catalog", label: "Skill catalog", tokens: 480, messages: 1 },
+    { key: "chat_user", label: "Chat · user inputs", tokens: 1900, messages: 4 },
+    { key: "chat_assistant", label: "Chat · assistant replies", tokens: 7300, messages: 6 },
+    { key: "reasoning", label: "Reasoning content", tokens: 1200, messages: 6 },
+    { key: "tool:bash", label: "Tool results · bash", tokens: 14200, messages: 3 },
+    { key: "tool:other", label: "Tool results · other", tokens: 1780, messages: 2 },
   ],
 };
 
@@ -56,20 +56,91 @@ const SUMMARY = {
 const page1 = () => contextBoardText({ breakdown: BREAKDOWN, latest_usage: LATEST_USAGE, index: 1, count: 2 }, 100);
 const page2 = () => usageBoardText({ summary: SUMMARY, index: 2, count: 2 }, 100);
 
-test("context board page 1 renders the locked layout", () => {
+test("context board page 1 renders the locked layout in assembly order", () => {
   resetTheme();
   const text = page1();
   const lines = text.split("\n").map(stripAnsi);
 
   assert.match(lines[0], /^┌ Context · last sampling · turn 8f3a · 03:33:12 ─+ 1\/2 ┐$/);
-  assert.equal(lines[1], "│ Window 131,072 · used 32%   measured 43,850 · estimated 41,320 (+6%)                             │");
+  assert.equal(lines[1], "│ Window 131,072 · used 32%   measured 43,850 · estimated ~41,320 (+6%)                            │");
   assert.match(lines[2], /^│ █+░+ │$/);
-  assert.equal(lines[4], "│   Tool results · bash            14,200   34%  3 msgs                                            │");
-  assert.equal(lines[5], "│   System prompt (incl. capsule)  12,400   30%   1 msg                                            │");
+  assert.deepEqual(
+    lines.slice(4, 12).map((line) => line.replace(/^│\s+/, "").split(/\s{2,}/)[0]),
+    [
+      "System prompt (incl. capsule)",
+      "RIND.md · project",
+      "Skill catalog",
+      "Chat · user inputs",
+      "Chat · assistant replies",
+      "Reasoning content",
+      "Tool results · bash",
+      "Tool results · other",
+    ],
+  );
+  assert.equal(lines[4], "│   System prompt (incl. capsule)  12,400   30%   1 msg                                            │");
+  assert.equal(lines[10], "│   Tool results · bash            14,200   34%  3 msgs                                            │");
   assert.equal(lines.at(-2), "│ Tab switch page · Esc exit                                                                       │");
   assert.equal(lines.at(-1), `└${"─".repeat(98)}┘`);
   // Byte-deterministic: the same input renders the same bytes.
   assert.equal(page1(), page1());
+});
+
+test("bar segments and underline labels follow the assembly order", () => {
+  resetTheme();
+  setTheme("mocha");
+  const originalIsTty = process.stdout.isTTY;
+  try {
+    process.stdout.isTTY = true;
+    const rawLines = page1().split("\n");
+
+    const underline = stripAnsi(rawLines[3]);
+    assert.ok(underline.indexOf("system") < underline.indexOf("chat"), "system label precedes chat");
+    assert.ok(underline.indexOf("chat") < underline.indexOf("bash"), "chat label precedes bash");
+
+    // The first two bar segments (system prompt, RIND.md) lead with the
+    // palette's first two roles — the bar fills in declaration order.
+    const codes = rawLines[2].match(/\x1b\[38;2;\d+;\d+;\d+m/g) || [];
+    assert.equal(codes[0], "\x1b[38;2;137;180;250m", "accent leads the stacked bar");
+    assert.equal(codes[1], "\x1b[38;2;166;227;161m", "success follows for the next section");
+  } finally {
+    if (originalIsTty === undefined) {
+      delete process.stdout.isTTY;
+    } else {
+      process.stdout.isTTY = originalIsTty;
+    }
+    resetTheme();
+  }
+});
+
+test("composer header carries a threshold-colored ctx segment from measured stats", () => {
+  resetTheme();
+  setTheme("mocha");
+  const originalIsTty = process.stdout.isTTY;
+  try {
+    process.stdout.isTTY = true;
+    const header = (stats) => stripAnsi(promptText({ model: "m1", cwd: "/p" }, stats, {}, 100).split("\n")[1]);
+    const raw = (stats) => promptText({ model: "m1", cwd: "/p" }, stats, {}, 100).split("\n")[1];
+
+    // Absent or zero stats keep the header clean.
+    assert.doesNotMatch(header({}), /ctx /);
+    assert.doesNotMatch(header({ context_usage_percent: 0 }), /ctx /);
+    assert.match(header({ context_usage_percent: 0.33 }), / · ctx 33%$/);
+
+    // The percent rides the same occupancy ladder as the board meta line.
+    const dangerCode = "\x1b[38;2;243;139;168m";
+    const warningCode = "\x1b[38;2;249;226;175m";
+    assert.ok(raw({ context_usage_percent: 0.7 }).includes(warningCode), "70% paints warn");
+    assert.ok(raw({ context_usage_percent: 0.9 }).includes(dangerCode), "90% paints err");
+    const neutral = raw({ context_usage_percent: 0.33 });
+    assert.ok(!neutral.includes(warningCode) && !neutral.includes(dangerCode), "33% stays neutral");
+  } finally {
+    if (originalIsTty === undefined) {
+      delete process.stdout.isTTY;
+    } else {
+      process.stdout.isTTY = originalIsTty;
+    }
+    resetTheme();
+  }
 });
 
 test("usage board page 2 renders the locked layout", () => {

--- a/frontend-cli/test/context-board.test.js
+++ b/frontend-cli/test/context-board.test.js
@@ -1,0 +1,312 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { createCliInputActions } from "../lib/cli-input-actions.js";
+import { createCliRuntimeController } from "../lib/cli-runtime-controller.js";
+import { createCommandController } from "../lib/command-controller.js";
+import { createCliState } from "../lib/cli-state.js";
+import { contextBoardText, occupancyTone, usageBoardText } from "../lib/rendering.js";
+import { resetTheme, setTheme } from "../lib/theme.js";
+import { stripAnsi, textWidth } from "../lib/text-width.js";
+
+const BREAKDOWN = {
+  captured_at: "2026-09-10T03:33:12.000Z",
+  turn_id: "8f3a12bc",
+  estimated_total: 41320,
+  context_window_tokens: 131072,
+  sections: [
+    { key: "tool:bash", label: "Tool results · bash", tokens: 14200, messages: 3 },
+    { key: "system_prompt", label: "System prompt (incl. capsule)", tokens: 12400, messages: 1 },
+    { key: "chat_assistant", label: "Chat · assistant replies", tokens: 7300, messages: 6 },
+    { key: "rind_docs_project", label: "RIND.md · project", tokens: 2100, messages: 1 },
+    { key: "chat_user", label: "Chat · user inputs", tokens: 1900, messages: 4 },
+    { key: "tool:other", label: "Tool results · other", tokens: 1780, messages: 2 },
+    { key: "reasoning", label: "Reasoning content", tokens: 1200, messages: 6 },
+    { key: "skill_catalog", label: "Skill catalog", tokens: 480, messages: 1 },
+  ],
+};
+
+const LATEST_USAGE = { sampling_kind: "assistant", input_tokens: 43850 };
+
+const SUMMARY = {
+  days: 7,
+  totals: { input: 1240000, cached: 812000, output: 96000, reasoning: 41000, total: 1336000, samples: 214, compactions: 6 },
+  by_day: [
+    { day: "09-09", tokens: 38200 },
+    { day: "09-08", tokens: 21400 },
+    { day: "09-07", tokens: 8900 },
+  ],
+  by_model: [
+    { model: "deepseek-v4-flash", tokens: 1180000, samples: 180 },
+    { model: "gpt-5-mini", tokens: 62000, samples: 34 },
+  ],
+  recent_sessions: [
+    { session_id: "20260909_1133", updated_at: "2026-09-09T11:33:00Z", tokens: 41200, samples: 12 },
+    { session_id: "20260908_2201", updated_at: "2026-09-08T22:01:00Z", tokens: 33000, samples: 10 },
+  ],
+};
+
+const page1 = () => contextBoardText({ breakdown: BREAKDOWN, latest_usage: LATEST_USAGE, index: 1, count: 2 }, 100);
+const page2 = () => usageBoardText({ summary: SUMMARY, index: 2, count: 2 }, 100);
+
+test("context board page 1 renders the locked layout", () => {
+  resetTheme();
+  const text = page1();
+  const lines = text.split("\n").map(stripAnsi);
+
+  assert.match(lines[0], /^┌ Context · last sampling · turn 8f3a · 03:33:12 ─+ 1\/2 ┐$/);
+  assert.equal(lines[1], "│ Window 131,072 · used 32%   measured 43,850 · estimated 41,320 (+6%)                             │");
+  assert.match(lines[2], /^│ █+░+ │$/);
+  assert.equal(lines[4], "│   Tool results · bash            14,200   34%  3 msgs                                            │");
+  assert.equal(lines[5], "│   System prompt (incl. capsule)  12,400   30%   1 msg                                            │");
+  assert.equal(lines.at(-2), "│ Tab switch page · Esc exit                                                                       │");
+  assert.equal(lines.at(-1), `└${"─".repeat(98)}┘`);
+  // Byte-deterministic: the same input renders the same bytes.
+  assert.equal(page1(), page1());
+});
+
+test("usage board page 2 renders the locked layout", () => {
+  resetTheme();
+  const text = page2();
+  const lines = text.split("\n").map(stripAnsi);
+
+  assert.match(lines[0], /^┌ Token usage · last 7 days ─+ 2\/2 ┐$/);
+  assert.equal(lines[1], "│ Input 1.24M   Cache hit 812K·65%   Output 96K   Reasoning 41K                                    │");
+  assert.equal(lines[2], "│ 214 samples                                                                                      │");
+  assert.match(lines[4], /^│ By day\s+│$/);
+  assert.match(lines[5], /^│ {3}09-09  █+\s+38\.2K │$/);
+  assert.match(lines[6], /^│ {3}09-08  █+\s+21\.4K │$/);
+  assert.match(lines[7], /^│ {3}09-07  █+\s+8\.9K │$/);
+  assert.match(lines[9], /^│ By model\s+│$/);
+  assert.match(lines.at(-2), /^│ 6 compaction calls · Tab switch page · Esc exit\s+│$/);
+  assert.equal(page2(), page2());
+});
+
+test("stacked bar and day columns stretch between 60 and 100 columns without misaligned rows", () => {
+  resetTheme();
+  for (const width of [60, 80, 100]) {
+    for (const text of [
+      contextBoardText({ breakdown: BREAKDOWN, latest_usage: LATEST_USAGE, index: 1, count: 2 }, width),
+      usageBoardText({ summary: SUMMARY, index: 2, count: 2 }, width),
+    ]) {
+      const lines = text.split("\n");
+      for (const line of lines) {
+        assert.equal(textWidth(line), width, `row exceeds the panel at ${width}: ${stripAnsi(line)}`);
+      }
+    }
+  }
+});
+
+test("CJK and emoji section labels stay aligned with plain ones", () => {
+  resetTheme();
+  const breakdown = {
+    ...BREAKDOWN,
+    sections: [
+      { key: "chat_user", label: "Chat · 用户输入", tokens: 9000, messages: 4 },
+      { key: "chat_assistant", label: "Chat · replies 🚀", tokens: 7000, messages: 3 },
+      { key: "tool:other", label: "Tool results · other", tokens: 1000, messages: 2 },
+    ],
+  };
+  const text = contextBoardText({ breakdown, index: 1, count: 2 }, 90);
+  const rows = text.split("\n").map(stripAnsi).filter((line) => line.includes(" msgs"));
+  const tokens = ["9,000", "7,000", "1,000"];
+  const columns = rows.map((row, index) => textWidth(row.slice(0, row.indexOf(tokens[index]))));
+  assert.equal(rows.length, 3);
+  // Right-aligned numbers share one display column regardless of CJK/emoji label widths.
+  assert.ok(columns.every((column) => column === columns[0]), `token columns ${columns}`);
+  assert.ok(columns[0] > 0);
+});
+
+test("occupancy 33/70/90 percent picks neutral/warn/err theme colors", () => {
+  assert.equal(occupancyTone(0.33), "neutral");
+  assert.equal(occupancyTone(0.7), "warn");
+  assert.equal(occupancyTone(0.9), "err");
+  resetTheme();
+  setTheme("mocha");
+  const originalIsTty = process.stdout.isTTY;
+  try {
+    process.stdout.isTTY = true;
+    const bar = (percent) => {
+      const breakdown = { ...BREAKDOWN, estimated_total: Math.round(BREAKDOWN.context_window_tokens * percent) };
+      return contextBoardText({ breakdown, latest_usage: { input_tokens: 1 }, index: 1, count: 2 }, 80);
+    };
+    // The occupancy warning is the color of the `used NN%` figure on the meta line.
+    const metaLine = (text) => text.split("\n")[1];
+    const codes = (text) => metaLine(text).match(/\x1b\[38;2;\d+;\d+;\d+m/g) || [];
+    const dangerCode = "\x1b[38;2;243;139;168m";
+    const warningCode = "\x1b[38;2;249;226;175m";
+    assert.ok(codes(bar(0.9)).includes(dangerCode), "90% occupancy paints err");
+    assert.ok(codes(bar(0.7)).includes(warningCode), "70% occupancy paints warn");
+    assert.deepEqual(codes(bar(0.33)), [], "33% occupancy stays neutral");
+  } finally {
+    if (originalIsTty === undefined) {
+      delete process.stdout.isTTY;
+    } else {
+      process.stdout.isTTY = originalIsTty;
+    }
+    resetTheme();
+  }
+});
+
+test("board render functions contain no hardcoded colors", () => {
+  const source = readFileSync(new URL("../lib/rendering.js", import.meta.url), "utf8");
+  // Single source of color is theme.js; render functions may only reference it.
+  assert.equal(source.includes("\\x1b["), false);
+  assert.equal(/38;2;/.test(source), false);
+  assert.equal(source.includes('from "./theme.js"'), true);
+  for (const role of ["accent", "dim", "success", "warning", "danger", "notice", "path", "code", "fence"]) {
+    assert.equal(source.includes(`paint.${role}`) || new RegExp(`paint\\[`).test(source), true, `paint.${role} usage`);
+  }
+});
+
+test("board keys switch pages and Esc exits with zero residual state", async () => {
+  const state = createCliState();
+  state.runtime.status = "ready";
+  const renderedPages = [];
+  const output = {
+    terminalUi: {},
+    writeUserInput() {},
+    closeAssistant() {},
+    beginQuestion() {},
+    finishQuestion() {},
+    redraw() {},
+    writeError() {},
+  };
+  const actions = createCliInputActions({
+    state,
+    request: async () => ({}),
+    output,
+    getTurnController: () => null,
+    getTaskMonitor: () => null,
+    getLineInput: () => null,
+    pausePrompt() {},
+    resumePrompt() {},
+    handleSigint() {},
+  });
+
+  const board = {
+    render: (pageIndex, width) => {
+      renderedPages.push([pageIndex, width]);
+      return `page-${pageIndex}@${width}`;
+    },
+  };
+  const pending = actions.askContextBoard(board);
+  await Promise.resolve();
+
+  const session = state.input.session;
+  assert.equal(session.mode, "context-board");
+  assert.equal(session.pageIndex, 0);
+
+  actions.handleTerminalInput("\t");
+  assert.equal(session.pageIndex, 1);
+  actions.handleTerminalInput("\x1b[C");
+  assert.equal(session.pageIndex, 0);
+  actions.handleTerminalInput("\x1b[D");
+  assert.equal(session.pageIndex, 1);
+
+  const frame = board.render(session.pageIndex, 100);
+  assert.equal(frame, "page-1@100");
+
+  actions.handleTerminalInput("\x1b");
+  assert.equal(await pending, "");
+  assert.equal(state.input.session, null);
+  assert.equal(state.input.active, false);
+});
+
+test("empty sampling state shows the exact guidance copy", () => {
+  resetTheme();
+  const text = contextBoardText({ breakdown: null, latest_usage: null, index: 1, count: 2 }, 80);
+  assert.match(text, /No context sampled yet/);
+  assert.match(text, /Send a message first, then try again\./);
+  assert.doesNotMatch(text, /█/);
+  const usage = usageBoardText({ summary: { days: 7, totals: { samples: 0 } }, index: 2, count: 2 }, 80);
+  assert.match(usage, /No usage recorded yet/);
+  assert.match(usage, /Send a message first, then try again\./);
+});
+
+test("non-TTY /context prints both pages as plain frame-less text", async () => {
+  const state = createCliState();
+  state.runtime.status = "ready";
+  state.session.info = { session_id: "session-a", model: "model-a" };
+  const requests = [];
+  const logs = [];
+  const methods = {
+    initialize: "initialize",
+    contextInspect: "rind/context/inspect",
+    usageSummary: "rind/usage/summary",
+    commandExecute: "rind/command/execute",
+  };
+  const controller = createCliRuntimeController({
+    client: {
+      start() {},
+      request(method, params) {
+        requests.push({ method, params });
+        if (method === methods.initialize) {
+          return Promise.resolve({ protocol_version: "2", capabilities: [], methods: [], session_id: "session-a" });
+        }
+        if (method === methods.contextInspect) {
+          return Promise.resolve({ session_id: "session-a", breakdown: BREAKDOWN, latest_usage: LATEST_USAGE });
+        }
+        if (method === methods.usageSummary) {
+          return Promise.resolve(SUMMARY);
+        }
+        return Promise.resolve({});
+      },
+    },
+    methods,
+    sessionScopedMethods: new Set([methods.contextInspect]),
+    turnScopedMethods: new Set(),
+    requireInitialization: (info) => info,
+    state,
+    getCommands: () => ({ normalizeCommands: (commands) => commands || [], localCommands: () => [], applyResult() {} }),
+    getTaskMonitor: () => null,
+    getCompactContextState: () => ({ clear() {} }),
+    restoreLiveTurn() {},
+    renderHistory() {},
+    clearPendingInputs() {},
+    closeAssistant() {},
+    refreshInputState() {},
+    updateGoalState() {},
+    log: (text) => logs.push(typeof text === "function" ? text() : text),
+    writeError() {},
+    redraw() {},
+  });
+
+  await controller.printContextReport();
+
+  assert.deepEqual(requests.map((request) => request.method), [methods.contextInspect, methods.usageSummary]);
+  assert.deepEqual(requests[0].params, { session_id: "session-a" });
+  assert.deepEqual(requests[1].params, { days: 7 });
+  assert.equal(logs.length, 2);
+  for (const text of logs) {
+    assert.equal(text.includes("┌"), false, "frame-less output must not draw borders");
+    assert.equal(text.includes("Tab switch page"), false, "interaction hints are meaningless in pipe output");
+  }
+  assert.match(logs[0], /Context · last sampling/);
+  assert.match(logs[1], /Token usage · last 7 days/);
+});
+
+test("/context routes to the board on a TTY and to the report otherwise", async () => {
+  const calls = [];
+  const makeController = (input) => createCommandController({
+    request: async () => ({}),
+    turn: { submit() {} },
+    input,
+    output: { log: (text) => calls.push(["log", typeof text === "function" ? text() : text]) },
+  });
+
+  await makeController({
+    isTerminal: true,
+    runContextBoard: () => calls.push(["board"]),
+    printContextReport: () => calls.push(["report"]),
+  }).handle("/context");
+  await makeController({
+    isTerminal: false,
+    runContextBoard: () => calls.push(["board"]),
+    printContextReport: () => calls.push(["report"]),
+  }).handle("/context");
+  await makeController({ isTerminal: false }).handle("/context");
+
+  assert.deepEqual(calls, [["board"], ["report"], ["log", "/context requires a connected runtime."]]);
+});

--- a/frontend-cli/test/context-board.test.js
+++ b/frontend-cli/test/context-board.test.js
@@ -6,8 +6,14 @@ import { createCliInputActions } from "../lib/cli-input-actions.js";
 import { createCliRuntimeController } from "../lib/cli-runtime-controller.js";
 import { createCommandController } from "../lib/command-controller.js";
 import { createCliState } from "../lib/cli-state.js";
+import { createCliOutputController } from "../lib/cli-output-controller.js";
+import { createVirtualOutput, createVirtualInput } from "./helpers/virtual-terminal.js";
+import { createTui } from "../lib/tui/tui.js";
+import { Container } from "../lib/tui/component.js";
+import { ComposerArea } from "../lib/components/composer-area.js";
+import { MonitorStack } from "../lib/components/monitor-stack.js";
 import { contextBoardText, occupancyTone, usageBoardText } from "../lib/rendering.js";
-import { resetTheme, setTheme } from "../lib/theme.js";
+import { resetTheme, setTheme, flavorSwatch } from "../lib/theme.js";
 import { stripAnsi, textWidth } from "../lib/text-width.js";
 
 const BREAKDOWN = {
@@ -309,4 +315,134 @@ test("/context routes to the board on a TTY and to the report otherwise", async 
   await makeController({ isTerminal: false }).handle("/context");
 
   assert.deepEqual(calls, [["board"], ["report"], ["log", "/context requires a connected runtime."]]);
+});
+
+test("every theme paints the board only with its own palette", () => {
+  const originalIsTty = process.stdout.isTTY;
+  try {
+    process.stdout.isTTY = true;
+    for (const theme of ["latte", "frappe", "macchiato", "mocha"]) {
+      resetTheme();
+      assert.equal(setTheme(theme)?.name, theme);
+      // The theme deck swatch enumerates this flavor's eight role colors.
+      const allowed = new Set(flavorSwatch(theme).match(/\x1b\[38;2;\d+;\d+;\d+m/g) || []);
+      assert.equal(allowed.size, 8);
+      for (const text of [
+        contextBoardText({ breakdown: BREAKDOWN, latest_usage: LATEST_USAGE, index: 1, count: 2 }, 100),
+        usageBoardText({ summary: SUMMARY, index: 2, count: 2 }, 100),
+      ]) {
+        const used = text.match(/\x1b\[38;2;\d+;\d+;\d+m/g) || [];
+        assert.ok(used.length > 0, `${theme}: board paints with truecolor`);
+        for (const code of used) {
+          assert.ok(allowed.has(code), `${theme}: unexpected color ${code}`);
+        }
+      }
+    }
+  } finally {
+    if (originalIsTty === undefined) {
+      delete process.stdout.isTTY;
+    } else {
+      process.stdout.isTTY = originalIsTty;
+    }
+    resetTheme();
+  }
+});
+
+test("board renders full screen on a real TUI, Tab flips pages, Esc returns to the composer", async () => {
+  const virtual = createVirtualOutput({ columns: 100, rows: 30 });
+  const input = createVirtualInput();
+  const tui = createTui({
+    input,
+    output: virtual.output,
+    renderIntervalMs: 0,
+    setTimeout: (fn) => setTimeout(fn, 0),
+    clearTimeout,
+  });
+  const state = createCliState();
+  state.runtime.status = "ready";
+  const transcriptContainer = new Container();
+  const composerArea = new ComposerArea((width) => composeFrame(width));
+  const monitorStack = new MonitorStack({
+    composer: composerArea,
+    monitor: { isMonitoring: () => false, frame: () => null },
+    rows: () => tui.rows,
+  });
+  tui.addChild(transcriptContainer);
+  tui.addChild(monitorStack);
+  const output = createCliOutputController({ state, terminalUi: tui, transcript: transcriptContainer });
+  // Mirrors the composeFrame board branch in frontend-cli-implementation.js.
+  function composeFrame(width) {
+    const session = state.input.session;
+    if (!session) {
+      return null;
+    }
+    if (session.mode === "context-board") {
+      return {
+        showCaret: false,
+        prompt: "",
+        inputText: "",
+        cursor: { line: 0, column: 0 },
+        menuText: session.board.render(session.pageIndex, width),
+      };
+    }
+    return { prompt: output.mainPromptText(width), inputText: "", cursor: { line: 0, column: 0 }, placeholder: "" };
+  }
+  const actions = createCliInputActions({
+    state,
+    request: async () => ({}),
+    output,
+    getTurnController: () => null,
+    getTaskMonitor: () => null,
+    getLineInput: () => null,
+    pausePrompt() {},
+    resumePrompt() {},
+    handleSigint() {},
+  });
+
+  const data = { breakdown: BREAKDOWN, latestUsage: LATEST_USAGE, summary: SUMMARY };
+  const renderPage = (pageIndex, width) => (pageIndex === 0
+    ? contextBoardText({ breakdown: data.breakdown, latest_usage: data.latestUsage, index: 1, count: 2 }, width)
+    : usageBoardText({ summary: data.summary, index: 2, count: 2 }, width));
+  tui.onData((sequence) => actions.handleTerminalInput(sequence));
+  tui.start();
+
+  const pending = actions.askContextBoard({ render: renderPage });
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  await virtual.flush();
+
+  let viewport = virtual.getViewport().map((line) => stripAnsi(line)).filter((line) => line.trim());
+  let flat = viewport.join("\n");
+  assert.match(flat, /Context · last sampling · turn 8f3a/);
+  assert.match(flat, /1\/2/);
+  assert.match(flat, /Tool results · bash/);
+  assert.equal(flat.includes("Token usage · last 7 days"), false, "page 2 stays hidden on page 1");
+
+  input.send("\t");
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  await virtual.flush();
+  viewport = virtual.getViewport().map((line) => stripAnsi(line)).filter((line) => line.trim());
+  flat = viewport.join("\n");
+  assert.match(flat, /Token usage · last 7 days/);
+  assert.match(flat, /2\/2/);
+  assert.match(flat, /6 compaction calls/);
+  assert.equal(flat.includes("Tool results · bash"), false, "page 1 stays hidden on page 2");
+
+  input.send("\x1b[C");
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  await virtual.flush();
+  viewport = virtual.getViewport().map((line) => stripAnsi(line)).filter((line) => line.trim());
+  assert.match(viewport.join("\n"), /Context · last sampling/, "arrow right returns to page 1");
+
+  input.send("\x1b");
+  assert.equal(await pending, "");
+  assert.equal(state.input.session, null);
+  assert.equal(state.input.active, false);
+
+  state.input.session = { mode: "prompt" };
+  tui.requestRender(true);
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  await virtual.flush();
+  viewport = virtual.getViewport().map((line) => stripAnsi(line)).filter((line) => line.trim());
+  assert.equal(viewport.join("\n").includes("Context · last sampling"), false, "the board leaves no residue");
+  tui.stop();
 });

--- a/frontend-cli/test/context-board.test.js
+++ b/frontend-cli/test/context-board.test.js
@@ -317,6 +317,27 @@ test("/context routes to the board on a TTY and to the report otherwise", async 
   assert.deepEqual(calls, [["board"], ["report"], ["log", "/context requires a connected runtime."]]);
 });
 
+test("/context with a custom range explains the fallback and still opens the board", async () => {
+  const calls = [];
+  const controller = createCommandController({
+    request: async () => ({}),
+    turn: { submit() {} },
+    input: {
+      isTerminal: true,
+      runContextBoard: () => calls.push(["board"]),
+      printContextReport: () => calls.push(["report"]),
+    },
+    output: { log: (text) => calls.push(["log", typeof text === "function" ? text() : text]) },
+  });
+
+  await controller.handle("/context 30");
+
+  assert.deepEqual(calls, [
+    ["log", "Custom ranges are not supported yet; showing the last 7 days."],
+    ["board"],
+  ]);
+});
+
 test("every theme paints the board only with its own palette", () => {
   const originalIsTty = process.stdout.isTTY;
   try {

--- a/frontend-cli/test/rendering.test.js
+++ b/frontend-cli/test/rendering.test.js
@@ -149,7 +149,7 @@ test("prompt and turn status copy match the compact terminal UI", () => {
   assert.equal(outputBlockText(""), "");
 });
 
-test("promptText includes only model and working directory above the input", () => {
+test("promptText shows model, working directory, and ctx usage above the input", () => {
   assert.equal(
     promptText({ model: "glm-5.1", cwd: "E:\\code\\agent\\rind-ts-cli-process-split" }, {
       context_usage_percent: 0.125,
@@ -158,7 +158,7 @@ test("promptText includes only model and working directory above the input", () 
     }),
     [
       "",
-      "  glm-5.1 · E:\\code\\agent\\rind-ts-cli-process-split",
+      "  glm-5.1 · E:\\code\\agent\\rind-ts-cli-process-split · ctx 13%",
       "  enter send · ↑↓ history · / commands · ? help",
       `  ${"─".repeat(78)}`,
       "  ▷ ",
@@ -246,7 +246,8 @@ test("promptText clips long session status", () => {
   const statusLine = text.split("\n")[1];
 
   assert.ok(statusLine.length <= 80);
-  assert.match(statusLine, /\.\.\.$/);
+  assert.match(statusLine, /\.\.\./);
+  assert.match(statusLine, /ctx 25%$/);
 });
 
 test("promptText extends the divider to the terminal's right edge", () => {

--- a/frontend-cli/test/runtime-protocol.test.js
+++ b/frontend-cli/test/runtime-protocol.test.js
@@ -96,6 +96,8 @@ test("runtime protocol recognizes the shared golden event fixture", () => {
     "delete-1",
     "fork-1",
     "ping-1",
+    "context-inspect-1",
+    "usage-summary-1",
   ]);
   assert.deepEqual(responses.map(runtimeRequestId), [
     "turn-1",
@@ -108,6 +110,8 @@ test("runtime protocol recognizes the shared golden event fixture", () => {
     "delete-1",
     "fork-1",
     "ping-1",
+    "context-inspect-1",
+    "usage-summary-1",
   ]);
 });
 

--- a/test/fixtures/runtime_protocol.golden.jsonl
+++ b/test/fixtures/runtime_protocol.golden.jsonl
@@ -21,3 +21,7 @@
 {"kind":"response","request_id":"fork-1","result":{"session_id":"session-1-fork","forked_from":"session-1"}}
 {"kind":"request","request_id":"ping-1","method":"ping","params":{}}
 {"kind":"response","request_id":"ping-1","result":{"ok":true}}
+{"kind":"request","request_id":"context-inspect-1","method":"rind/context/inspect","params":{"session_id":"session-1"}}
+{"kind":"response","request_id":"context-inspect-1","result":{"session_id":"session-1","breakdown":{"captured_at":"2026-01-01T00:00:04Z","turn_id":"turn-1","estimated_total":120,"context_window_tokens":1000,"sections":[{"key":"chat_user","label":"Chat · user inputs","tokens":120,"messages":1}]},"latest_usage":{"sampling_kind":"assistant","input_tokens":118,"cached_input_tokens":0,"cache_hit_rate":0.0,"output_tokens":21,"reasoning_output_tokens":0,"total_tokens":139,"context_window_tokens":1000,"context_usage_percent":0.118}}}
+{"kind":"request","request_id":"usage-summary-1","method":"rind/usage/summary","params":{"days":7}}
+{"kind":"response","request_id":"usage-summary-1","result":{"days":7,"totals":{"input":118,"cached":0,"output":21,"reasoning":0,"total":139,"samples":1,"compactions":0},"by_day":[{"day":"01-01","tokens":139}],"by_model":[{"model":"test-model","tokens":139,"samples":1}],"recent_sessions":[{"session_id":"session-1","updated_at":"2026-01-01T00:00:04Z","tokens":139,"samples":1}]}}

--- a/test/helpers/fake_openai_server.py
+++ b/test/helpers/fake_openai_server.py
@@ -41,7 +41,6 @@ class FakeOpenAIServer:
     def script_error(self, status: int = 500) -> None:
         with self._lock:
             self._script.append({"kind": "error", "status": status})
-
     # -- lifecycle -----------------------------------------------------------
 
     def start(self, port: int = 0) -> None:
@@ -73,6 +72,29 @@ class FakeOpenAIServer:
                 if script["kind"] == "error":
                     self._reply(script["status"], {"error": {"message": "scripted failure"}})
                     return
+                if not body.get("stream"):
+                    # Non-streaming callers (compaction) expect one JSON completion.
+                    prompt_chars = sum(len(str(m.get("content") or "")) for m in body.get("messages", []))
+                    content = "".join(script.get("chunks", [])) if script["kind"] == "text" else ""
+                    self._reply(200, {
+                        "id": "chatcmpl-test",
+                        "object": "chat.completion",
+                        "created": int(time.time()),
+                        "model": str(body.get("model") or "fake-model"),
+                        "choices": [{
+                            "index": 0,
+                            "message": {"role": "assistant", "content": content or "(no script)"},
+                            "finish_reason": "stop",
+                        }],
+                        "usage": {
+                            "prompt_tokens": int(prompt_chars / 3.5) + 2,
+                            "completion_tokens": 21,
+                            "total_tokens": int(prompt_chars / 3.5) + 23,
+                            "prompt_tokens_details": {"cached_tokens": 0},
+                            "completion_tokens_details": {"reasoning_tokens": 0},
+                        },
+                    })
+                    return
                 self.send_response(200)
                 self.send_header("Content-Type", "text/event-stream")
                 self.send_header("Cache-Control", "no-cache")
@@ -97,6 +119,22 @@ class FakeOpenAIServer:
                          "function": {"name": script["name"], "arguments": arguments}},
                     ]}))
                     emit(self._chunk(request_id, created, model, {}, finish="tool_calls"))
+                    if body.get("stream_options", {}).get("include_usage"):
+                        prompt_chars = sum(len(str(m.get("content") or "")) for m in body.get("messages", []))
+                        emit({
+                            "id": request_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "choices": [],
+                            "usage": {
+                                "prompt_tokens": int(prompt_chars / 3.5) + 2,
+                                "completion_tokens": 21,
+                                "total_tokens": int(prompt_chars / 3.5) + 23,
+                                "prompt_tokens_details": {"cached_tokens": 0},
+                                "completion_tokens_details": {"reasoning_tokens": 0},
+                            },
+                        })
                     self.wfile.write(b"data: [DONE]\n\n")
                     self.wfile.flush()
                     return
@@ -108,6 +146,23 @@ class FakeOpenAIServer:
                     if script["delay_ms"]:
                         time.sleep(script["delay_ms"] / 1000.0)
                 emit(self._chunk(request_id, created, model, {}, finish=script.get("finish", "stop")))
+                if body.get("stream_options", {}).get("include_usage"):
+                    # Providers echo measured usage on a choices-free final chunk.
+                    prompt_chars = sum(len(str(m.get("content") or "")) for m in body.get("messages", []))
+                    emit({
+                        "id": request_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": model,
+                        "choices": [],
+                        "usage": {
+                            "prompt_tokens": int(prompt_chars / 3.5) + 2,
+                            "completion_tokens": 21,
+                            "total_tokens": int(prompt_chars / 3.5) + 23,
+                            "prompt_tokens_details": {"cached_tokens": 0},
+                            "completion_tokens_details": {"reasoning_tokens": 0},
+                        },
+                    })
                 self.wfile.write(b"data: [DONE]\n\n")
                 self.wfile.flush()
 

--- a/test/test_context_journeys.py
+++ b/test/test_context_journeys.py
@@ -1,0 +1,240 @@
+"""User-seat /context journeys: a real worker subprocess speaking the same
+stdio JSONL transport the CLI drives, scripted by the fake model server.
+
+These assert what a user perceives after real turns — the board's numbers —
+not implementation details: composition rows after a chat exchange, tool
+rows after bash use, the compaction-handoff row and page-2 counter after
+/compact, and a snapshot that follows a fork."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+if str(PROJECT_ROOT / "test") not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT / "test"))
+
+from helpers.fake_openai_server import FakeOpenAIServer
+
+
+class StdioWorkerClient:
+    """The CLI's seat: JSONL requests and event envelopes over worker stdio."""
+
+    def __init__(self, process):
+        self._process = process
+        self._lock = threading.Lock()
+        self._responses: dict[object, dict] = {}
+        self._events: list[dict] = []
+
+        def _pump():
+            for line in self._process.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    envelope = json.loads(line)
+                except ValueError:
+                    continue
+                with self._lock:
+                    if envelope.get("kind") == "response":
+                        self._responses[envelope.get("request_id")] = envelope
+                    elif envelope.get("kind") == "event":
+                        self._events.append(envelope)
+
+        self._pump_thread = threading.Thread(target=_pump, daemon=True)
+        self._pump_thread.start()
+
+    def request(self, method: str, params: dict | None = None, timeout: float = 60.0) -> dict:
+        request_id = f"req-{time.monotonic_ns()}"
+        payload = {"kind": "request", "request_id": request_id, "method": method, "params": params or {}}
+        with self._lock:
+            self._responses.pop(request_id, None)
+        self._process.stdin.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        self._process.stdin.flush()
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._lock:
+                envelope = self._responses.pop(request_id, None)
+            if envelope is not None:
+                if "error" in envelope:
+                    raise AssertionError(f"{method} failed: {envelope['error']}")
+                return envelope.get("result") or {}
+            time.sleep(0.02)
+        raise TimeoutError(f"{method} timed out")
+
+    def run_prompt(self, session_id: str, text: str, timeout: float = 90.0) -> dict:
+        return self.request("session/prompt", {"session_id": session_id, "input": text}, timeout=timeout)
+
+    def ledger_rows(self, home: Path) -> list[dict]:
+        ledger = home / "usage.jsonl"
+        if not ledger.exists():
+            return []
+        return [json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+@pytest.fixture(scope="module")
+def context_worker(tmp_path_factory):
+    """One real worker subprocess; a scratch workspace plus scratch RIND_HOME."""
+    root = tmp_path_factory.mktemp("context-journey")
+    workspace = root / "workspace"
+    (workspace / ".rind").mkdir(parents=True)
+    (workspace / ".rind" / "settings.json").write_text(
+        json.dumps({"model": "fake-model", "apiKey": "test-key", "baseUrl": "http://127.0.0.1:9/v1"}),
+        encoding="utf-8",
+    )
+    home = root / "home"
+    (home / ".rind").mkdir(parents=True)
+    env = dict(os.environ)
+    env.update({"RIND_HOME": str(home), "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"})
+    env.pop("RIND_WORKSPACE", None)
+    process = subprocess.Popen(
+        [
+            sys.executable, str(PROJECT_ROOT / "main.py"), "app-server", "--stdio",
+            "--cwd", str(workspace), "--session-dir", str(root / "sessions"),
+        ],
+        cwd=PROJECT_ROOT, env=env, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, encoding="utf-8",
+    )
+    yield type("Worker", (), {
+        "client": StdioWorkerClient(process),
+        "workspace": workspace,
+        "home": home,
+        "process": process,
+    })()
+    process.terminate()
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.kill()
+
+
+@pytest.fixture()
+def model_server(context_worker):
+    server = FakeOpenAIServer()
+    server.start()
+    settings_path = context_worker.workspace / ".rind" / "settings.json"
+    settings_path.write_text(
+        json.dumps({"model": "fake-model", "apiKey": "test-key", "baseUrl": server.base_url}),
+        encoding="utf-8",
+    )
+    yield server
+    server.stop()
+
+
+def _summarize_breakdown(result: dict) -> dict:
+    breakdown = result.get("breakdown") or {}
+    return {
+        section["key"]: section
+        for section in breakdown.get("sections") or []
+    }
+
+
+def test_jc1_fresh_exchange_shows_board_rows_with_small_deviation(context_worker, model_server):
+    client = context_worker.client
+    info = client.request("initialize", {})
+    session_id = info["session_id"]
+    model_server.script_text(["你好", "，很高兴见到你。"], delay_ms=1)
+    client.run_prompt(session_id, "打个招呼")
+
+    board = client.request("rind/context/inspect", {"session_id": session_id})
+    sections = _summarize_breakdown(board)
+    breakdown = board["breakdown"]
+
+    # Page 1 shows the composition of the LAST SAMPLING: after one exchange the
+    # reply was persisted after that sampling, so the fresh board shows three
+    # rows — system prompt, goal policy, and the user's message.
+    assert "chat_user" in sections
+    assert "system_prompt" in sections
+    assert "goal_policy" in sections
+    # Every number on page 1 traces to the snapshot: rows sum to the total.
+    assert sum(section["tokens"] for section in breakdown["sections"]) == breakdown["estimated_total"]
+    assert breakdown["context_window_tokens"] > 0
+    assert breakdown["turn_id"]
+    # The measured total anchors the page; deviation stays well under 15%.
+    usage = board["latest_usage"]
+    assert usage is not None and usage["input_tokens"] > 0
+    deviation = abs(usage["input_tokens"] - breakdown["estimated_total"]) / usage["input_tokens"]
+    assert deviation < 0.15, f"estimated {breakdown['estimated_total']} vs measured {usage['input_tokens']}"
+
+    # A second exchange samples WITH the first reply in context: the assistant
+    # row appears and the tools segment is still absent.
+    model_server.script_text(["第二次回答"], delay_ms=1)
+    client.run_prompt(session_id, "再问一句")
+    board = client.request("rind/context/inspect", {"session_id": session_id})
+    sections = _summarize_breakdown(board)
+    assert "chat_assistant" in sections
+    assert sections["chat_assistant"]["messages"] >= 1
+
+    summary = client.request("rind/usage/summary", {"days": 7})
+    assert summary["totals"]["samples"] >= 2
+    assert summary["totals"]["input"] >= usage["input_tokens"]
+    rows = client.ledger_rows(context_worker.home)
+    assert any(row["session_id"] == session_id and row["sampling_kind"] == "assistant" for row in rows)
+
+
+def test_jc2_bash_calls_widen_the_tool_segment(context_worker, model_server):
+    client = context_worker.client
+    info = client.request("initialize", {})
+    session_id = info["session_id"]
+    model_server.script_tool_call("bash", {"command": "echo journey-context"}, then_text=["done"])
+    client.run_prompt(session_id, "run echo via bash")
+
+    board = client.request("rind/context/inspect", {"session_id": session_id})
+    sections = _summarize_breakdown(board)
+
+    assert "tool:bash" in sections, f"tool rows missing: {sorted(sections)}"
+    assert sections["tool:bash"]["messages"] >= 1
+    assert sum(section["tokens"] for section in board["breakdown"]["sections"]) == board["breakdown"]["estimated_total"]
+
+
+def test_jc3_compact_replaces_history_and_counts_compactions(context_worker, model_server):
+    client = context_worker.client
+    info = client.request("initialize", {})
+    session_id = info["session_id"]
+    model_server.script_text(["first answer"], delay_ms=1)
+    client.run_prompt(session_id, "first question")
+
+    record = client.request("rind/session/compact", {"session_id": session_id})
+    assert record.get("id")
+
+    board = client.request("rind/context/inspect", {"session_id": session_id})
+    sections = _summarize_breakdown(board)
+    assert "compaction_handoff" in sections, f"handoff row missing: {sorted(sections)}"
+    assert "chat_user" not in sections or sections["compaction_handoff"]["tokens"] > 0
+
+    summary = client.request("rind/usage/summary", {"days": 7})
+    assert summary["totals"]["compactions"] >= 1
+    rows = client.ledger_rows(context_worker.home)
+    assert any(row["sampling_kind"] == "compact" for row in rows)
+
+
+def test_jc4_fork_inherits_snapshot_and_ledger_records_new_session(context_worker, model_server):
+    client = context_worker.client
+    info = client.request("initialize", {})
+    session_id = info["session_id"]
+    model_server.script_text(["before fork"], delay_ms=1)
+    client.run_prompt(session_id, "question before fork")
+
+    forked = client.request("session/fork", {"session_id": session_id})
+    new_id = forked["session_id"]
+
+    board = client.request("rind/context/inspect", {"session_id": new_id})
+    assert board["breakdown"] is not None
+    assert board["breakdown"]["estimated_total"] > 0
+    assert board["session_id"] == new_id
+
+    model_server.script_text(["after fork"], delay_ms=1)
+    client.run_prompt(new_id, "question after fork")
+    rows = client.ledger_rows(context_worker.home)
+    assert any(row["session_id"] == new_id and row["sampling_kind"] == "assistant" for row in rows)

--- a/test/test_context_journeys.py
+++ b/test/test_context_journeys.py
@@ -157,6 +157,8 @@ def test_jc1_fresh_exchange_shows_board_rows_with_small_deviation(context_worker
     assert "chat_user" in sections
     assert "system_prompt" in sections
     assert "goal_policy" in sections
+    # Assembly order: the system prompt row always leads the board.
+    assert breakdown["sections"][0]["key"] == "system_prompt"
     # Every number on page 1 traces to the snapshot: rows sum to the total.
     assert sum(section["tokens"] for section in breakdown["sections"]) == breakdown["estimated_total"]
     assert breakdown["context_window_tokens"] > 0
@@ -195,6 +197,7 @@ def test_jc2_bash_calls_widen_the_tool_segment(context_worker, model_server):
 
     assert "tool:bash" in sections, f"tool rows missing: {sorted(sections)}"
     assert sections["tool:bash"]["messages"] >= 1
+    assert board["breakdown"]["sections"][0]["key"] == "system_prompt"
     assert sum(section["tokens"] for section in board["breakdown"]["sections"]) == board["breakdown"]["estimated_total"]
 
 
@@ -212,6 +215,10 @@ def test_jc3_compact_replaces_history_and_counts_compactions(context_worker, mod
     sections = _summarize_breakdown(board)
     assert "compaction_handoff" in sections, f"handoff row missing: {sorted(sections)}"
     assert "chat_user" not in sections or sections["compaction_handoff"]["tokens"] > 0
+    keys = [section["key"] for section in board["breakdown"]["sections"]]
+    assert keys[0] == "system_prompt"
+    if "chat_user" in keys:
+        assert keys.index("compaction_handoff") < keys.index("chat_user")
 
     summary = client.request("rind/usage/summary", {"days": 7})
     assert summary["totals"]["compactions"] >= 1

--- a/test/test_context_snapshot.py
+++ b/test/test_context_snapshot.py
@@ -188,14 +188,64 @@ def test_missing_stats_fall_back_to_the_section_sum():
     assert snapshot["context_window_tokens"] > 0
 
 
-def test_sections_are_ranked_by_tokens_descending():
+def test_sections_follow_assembly_order():
+    # Token mass is inverted on purpose: the biggest payloads sit last, so only
+    # first-appearance order — not size — can produce this sequence.
     messages = [
-        {"role": "user", "content": "short"},
-        {"role": "assistant", "content": "a much longer assistant reply " * 20},
+        {"role": "system", "content": "sys"},
+        {"role": "system", "content": "--- user-doc ---\n\nu\n\n--- project-doc ---\n\np", "_context_kind": "rind_docs"},
+        {"role": "system", "content": "goal", "_context_kind": "goal_policy"},
+        {"role": "system", "content": "skills", "_context_kind": "skill_catalog"},
+        {"role": "user", "content": "hi " * 100},
+        {"role": "assistant", "content": "hello " * 60, "reasoning_content": "think " * 60},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "type": "function", "function": {"name": "zzz_tool", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "out " * 80},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c2", "type": "function", "function": {"name": "aaa_tool", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "c2", "content": "o " * 400},
     ]
-    stats = {"estimated_input_tokens": 0, "context_window_tokens": 8192}
+    stats = pipeline_stats(messages)
 
     snapshot = build_context_snapshot(messages, stats, "", estimator=ESTIMATOR)
+    keys = [section["key"] for section in snapshot["sections"]]
 
-    tokens = [section["tokens"] for section in snapshot["sections"]]
-    assert tokens == sorted(tokens, reverse=True)
+    assert keys == [
+        "system_prompt",
+        "rind_docs_user",
+        "rind_docs_project",
+        "goal_policy",
+        "skill_catalog",
+        "chat_user",
+        "chat_assistant",
+        "reasoning",
+        "tool:zzz_tool",
+        "tool:aaa_tool",
+    ]
+    # The heaviest section sits last: ordering follows assembly, not mass.
+    assert snapshot["sections"][-1]["tokens"] == max(
+        section["tokens"] for section in snapshot["sections"]
+    )
+
+
+def test_compaction_handoff_precedes_chat_rows():
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": COMPACT_CONTINUATION_USER_CONTENT},
+        {"role": "assistant", "content": "summary", "reasoning_content": COMPACT_HANDOFF_REASONING_CONTENT},
+        {"role": "user", "content": "fresh question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+
+    keys = [section["key"] for section in build_context_snapshot(messages, {}, "", estimator=ESTIMATOR)["sections"]]
+
+    assert keys[0] == "system_prompt"
+    assert keys.index("compaction_handoff") < keys.index("chat_user")
+
+
+def test_sections_carry_no_internal_order_field():
+    snapshot = build_context_snapshot([{"role": "user", "content": "hi"}], {}, "")
+
+    assert all(set(section) == {"key", "label", "tokens", "messages"} for section in snapshot["sections"])

--- a/test/test_context_snapshot.py
+++ b/test/test_context_snapshot.py
@@ -1,0 +1,201 @@
+"""Context composition snapshot bucketing rules."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from agent.application.context.estimator import ContextEstimator
+from agent.application.context.snapshot import build_context_snapshot
+from agent.domain.compaction import (
+    COMPACT_CONTINUATION_USER_CONTENT,
+    COMPACT_HANDOFF_REASONING_CONTENT,
+)
+
+
+ESTIMATOR = ContextEstimator()
+
+
+def _sections(snapshot):
+    return {section["key"]: section for section in snapshot["sections"]}
+
+
+def test_mixed_messages_produce_the_full_bucket_set():
+    messages = [
+        {"role": "system", "content": "You are Rind. " * 10},
+        {"role": "system", "content": "--- user-doc ---\n\nuser doc", "_context_kind": "rind_docs"},
+        {"role": "system", "content": "catalog", "_context_kind": "skill_catalog"},
+        {"role": "system", "content": "goal policy", "_context_kind": "goal_policy"},
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there", "reasoning_content": "chain of thought"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "type": "function", "function": {"name": "bash", "arguments": "{}"}},
+            {"id": "c2", "type": "function", "function": {"name": "read_file", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "out1"},
+        {"role": "tool", "tool_call_id": "c1", "content": "out1b"},
+        {"role": "tool", "tool_call_id": "c2", "content": "file body"},
+        {"role": "user", "content": "continue", "meta": {"kind": "compact_boundary", "compact_id": "x"}},
+        {"role": "system", "content": "created", "_context_kind": "mystery_tag"},
+    ]
+    stats = pipeline_stats(messages)
+
+    snapshot = build_context_snapshot(messages, stats, "turn-1", estimator=ESTIMATOR)
+    sections = _sections(snapshot)
+
+    assert snapshot["estimated_total"] == stats["estimated_input_tokens"]
+    assert snapshot["context_window_tokens"] == 4096
+    assert snapshot["turn_id"] == "turn-1"
+    assert snapshot["captured_at"]
+    assert sum(section["tokens"] for section in snapshot["sections"]) == stats["estimated_input_tokens"]
+    for key in (
+        "system_prompt",
+        "rind_docs_user",
+        "skill_catalog",
+        "goal_policy",
+        "chat_user",
+        "chat_assistant",
+        "reasoning",
+        "tool:bash",
+        "tool:read_file",
+        "compaction_handoff",
+        "kind:mystery_tag",
+    ):
+        assert key in sections, f"missing bucket {key}"
+    assert sections["tool:bash"]["messages"] == 2
+    assert sections["tool:read_file"]["messages"] == 1
+    # Unknown tags form their own bucket under their original name.
+    assert sections["kind:mystery_tag"]["label"] == "mystery_tag"
+
+
+def pipeline_stats(messages):
+    estimate = ESTIMATOR.estimate_messages(messages)
+    return {
+        "estimated_input_tokens": estimate.estimated_input_tokens,
+        "context_window_tokens": 4096,
+    }
+
+
+def test_section_tokens_sum_to_the_stats_total_with_zero_drift():
+    messages = [
+        {"role": "system", "content": "system prompt " * 20},
+        {"role": "system", "content": "--- user-doc ---\n\nuser\n\n--- project-doc ---\n\nproject", "_context_kind": "rind_docs"},
+        {"role": "user", "content": "question? " * 5},
+        {"role": "assistant", "content": "answer " * 10, "reasoning_content": "thinking " * 8},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c9", "type": "function", "function": {"name": "bash", "arguments": "ls"}},
+        ]},
+        {"role": "tool", "tool_call_id": "c9", "content": "output " * 30},
+    ]
+    stats = pipeline_stats(messages)
+
+    snapshot = build_context_snapshot(messages, stats, "", estimator=ESTIMATOR)
+
+    assert sum(section["tokens"] for section in snapshot["sections"]) == stats["estimated_input_tokens"]
+    assert snapshot["estimated_total"] == stats["estimated_input_tokens"]
+
+
+def test_rind_docs_with_two_scopes_splits_into_two_rows():
+    messages = [
+        {
+            "role": "system",
+            "content": "--- user-doc ---\n\n" + "user rules " * 30 + "\n\n--- project-doc ---\n\n" + "project rules " * 30,
+            "_context_kind": "rind_docs",
+        },
+    ]
+    stats = {"estimated_input_tokens": 500, "context_window_tokens": 8192}
+
+    sections = _sections(build_context_snapshot(messages, stats, "", estimator=ESTIMATOR))
+
+    assert set(sections) == {"rind_docs_user", "rind_docs_project"}
+    assert sections["rind_docs_user"]["label"] == "RIND.md · user"
+    assert sections["rind_docs_project"]["label"] == "RIND.md · project"
+    assert sections["rind_docs_user"]["tokens"] > 0
+    assert sections["rind_docs_project"]["tokens"] > 0
+
+
+def test_same_name_tools_aggregate_and_six_tools_yield_an_other_row():
+    messages = [
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": f"c{i}", "type": "function", "function": {"name": name, "arguments": "{}"}},
+        ]}
+        for i, name in enumerate(["bash", "bash", "bash", "t1", "t2", "t3", "t4", "t5", "t6"])
+    ]
+    for i in range(9):
+        messages.append({"role": "tool", "tool_call_id": f"c{i}", "content": "out"})
+    stats = {"estimated_input_tokens": 800, "context_window_tokens": 8192}
+
+    sections = _sections(build_context_snapshot(messages, stats, "", estimator=ESTIMATOR))
+
+    assert sections["tool:bash"]["messages"] == 3
+    for name in ("t1", "t2", "t3", "t4"):
+        assert sections[f"tool:{name}"]["messages"] == 1
+    # Six distinct tools beyond bash: the four most frequent get rows, the rest merge.
+    assert "tool:t5" not in sections
+    assert "tool:t6" not in sections
+    assert sections["tool:other"]["messages"] == 2
+    assert sections["tool:other"]["label"] == "Tool results · other"
+
+
+def test_compaction_handoff_constants_bucket_together():
+    messages = [
+        {"role": "user", "content": COMPACT_CONTINUATION_USER_CONTENT},
+        {"role": "assistant", "content": "summary", "reasoning_content": COMPACT_HANDOFF_REASONING_CONTENT},
+        {"role": "user", "content": "fresh question"},
+    ]
+    stats = {"estimated_input_tokens": 300, "context_window_tokens": 8192}
+
+    sections = _sections(build_context_snapshot(messages, stats, "", estimator=ESTIMATOR))
+
+    assert sections["compaction_handoff"]["messages"] == 2
+    assert sections["compaction_handoff"]["label"] == "Compaction handoff"
+    assert sections["chat_user"]["messages"] == 1
+
+
+def test_assistant_reasoning_splits_into_its_own_bucket():
+    messages = [
+        {"role": "assistant", "content": "visible answer " * 20, "reasoning_content": "hidden reasoning " * 20},
+    ]
+    stats = {"estimated_input_tokens": 0, "context_window_tokens": 8192}
+
+    sections = _sections(build_context_snapshot(messages, stats, "", estimator=ESTIMATOR))
+
+    assert sections["chat_assistant"]["tokens"] > 0
+    assert sections["reasoning"]["tokens"] > 0
+    assert sections["chat_assistant"]["tokens"] + sections["reasoning"]["tokens"] == (
+        ESTIMATOR.estimate_messages(messages).estimated_input_tokens
+    )
+
+
+def test_empty_message_list_does_not_throw():
+    snapshot = build_context_snapshot([], {"estimated_input_tokens": 0, "context_window_tokens": 100}, "")
+
+    assert snapshot["sections"] == []
+    assert snapshot["estimated_total"] == 0
+    assert snapshot["context_window_tokens"] == 100
+
+
+def test_missing_stats_fall_back_to_the_section_sum():
+    messages = [{"role": "user", "content": "only message"}]
+
+    snapshot = build_context_snapshot(messages, {}, "")
+
+    assert snapshot["estimated_total"] == sum(section["tokens"] for section in snapshot["sections"])
+    assert snapshot["context_window_tokens"] > 0
+
+
+def test_sections_are_ranked_by_tokens_descending():
+    messages = [
+        {"role": "user", "content": "short"},
+        {"role": "assistant", "content": "a much longer assistant reply " * 20},
+    ]
+    stats = {"estimated_input_tokens": 0, "context_window_tokens": 8192}
+
+    snapshot = build_context_snapshot(messages, stats, "", estimator=ESTIMATOR)
+
+    tokens = [section["tokens"] for section in snapshot["sections"]]
+    assert tokens == sorted(tokens, reverse=True)

--- a/test/test_runtime_server_context.py
+++ b/test/test_runtime_server_context.py
@@ -1,0 +1,206 @@
+"""rind/context/inspect and rind/usage/summary protocol behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from agent.infrastructure.persistence import JsonlSessionStore
+from agent.infrastructure.persistence.usage_ledger import append_usage_record
+from agent.runtime.server.stdio import WorkerStdioRuntimeServer
+from agent.runtime.server.worker import SessionRepository
+
+
+SESSION_ID = "20260910_alpha"
+
+
+class _FakeExecution:
+    def set_event_sink(self, sink):
+        pass
+
+    def active_session_ids(self):
+        return set()
+
+
+class _FakeWorker:
+    def __init__(self, tmp_path: Path):
+        self.workspace_root = str(tmp_path)
+        self.session_id = SESSION_ID
+        self.session_dir = str(tmp_path / "sessions")
+        self.execution = _FakeExecution()
+        self.repository = SessionRepository(session_dir=self.session_dir)
+        self.summary_calls = []
+
+    async def usage_summary(self, days: int) -> dict:
+        self.summary_calls.append(days)
+        return {"days": days, "totals": {"samples": 0}, "by_day": [], "by_model": [], "recent_sessions": []}
+
+
+class _CaptureWriter:
+    def __init__(self):
+        self.payloads = []
+
+    async def send(self, payload):
+        self.payloads.append(payload)
+
+
+def _make_server(worker: _FakeWorker) -> WorkerStdioRuntimeServer:
+    server = WorkerStdioRuntimeServer(worker, writer=_CaptureWriter())
+    server._initialized = True
+    return server
+
+
+def _request(method: str, params: dict) -> dict:
+    return {"kind": "request", "request_id": "r1", "method": method, "params": params}
+
+
+def _last(server: WorkerStdioRuntimeServer) -> dict:
+    return server._writer._writer.payloads[-1]
+
+
+def _seed_store(worker: _FakeWorker) -> JsonlSessionStore:
+    store = JsonlSessionStore(
+        session_dir=worker.session_dir,
+        session_id=SESSION_ID,
+        system_prompt="sys",
+        workspace_root=worker.workspace_root,
+    )
+
+    async def _run() -> None:
+        await store.initialize()
+        await store.persist_message("user", "hello")
+
+    asyncio.run(_run())
+    return store
+
+
+def test_inspect_returns_meta_breakdown_and_latest_usage(tmp_path):
+    worker = _FakeWorker(tmp_path)
+    store = _seed_store(worker)
+
+    async def _seed_meta():
+        await store.persist_context_breakdown({
+            "captured_at": "2026-09-10T00:00:00Z",
+            "turn_id": "turn-1",
+            "estimated_total": 321,
+            "context_window_tokens": 4096,
+            "sections": [{"key": "chat_user", "label": "Chat · user inputs", "tokens": 321, "messages": 1}],
+        })
+        await store.persist_sampling_usage({
+            "sampling_kind": "assistant",
+            "input_tokens": 118,
+            "cached_input_tokens": 0,
+            "cache_hit_rate": 0.0,
+            "output_tokens": 21,
+            "reasoning_output_tokens": 0,
+            "total_tokens": 139,
+            "context_window_tokens": 4096,
+            "context_usage_percent": 118 / 4096,
+        })
+
+    asyncio.run(_seed_meta())
+    server = _make_server(worker)
+    asyncio.run(server.dispatch(_request("rind/context/inspect", {"session_id": SESSION_ID})))
+
+    response = _last(server)
+    assert "error" not in response
+    result = response["result"]
+    assert result["session_id"] == SESSION_ID
+    assert result["breakdown"]["estimated_total"] == 321
+    assert result["breakdown"]["sections"][0]["key"] == "chat_user"
+    assert result["latest_usage"]["input_tokens"] == 118
+    assert result["latest_usage"]["sampling_kind"] == "assistant"
+
+
+def test_inspect_without_records_reports_an_explicit_empty_state(tmp_path):
+    worker = _FakeWorker(tmp_path)
+    _seed_store(worker)
+    server = _make_server(worker)
+
+    asyncio.run(server.dispatch(_request("rind/context/inspect", {"session_id": SESSION_ID})))
+
+    result = _last(server)["result"]
+    assert result["breakdown"] is None
+    assert result["latest_usage"] is None
+
+
+def test_inspect_unknown_session_is_session_not_found(tmp_path):
+    worker = _FakeWorker(tmp_path)
+    server = _make_server(worker)
+
+    asyncio.run(server.dispatch(_request("rind/context/inspect", {"session_id": "20260910_missing"})))
+
+    response = _last(server)
+    assert response["error"]["type"] == "SessionNotFound"
+
+
+def test_summary_forwards_days_and_requires_a_valid_range(tmp_path):
+    worker = _FakeWorker(tmp_path)
+    server = _make_server(worker)
+
+    asyncio.run(server.dispatch(_request("rind/usage/summary", {"days": 30})))
+    assert worker.summary_calls == [30]
+    assert _last(server)["result"]["days"] == 30
+
+    asyncio.run(server.dispatch(_request("rind/usage/summary", {"days": 0})))
+    assert _last(server)["error"]["type"] == "InvalidRequest"
+
+    asyncio.run(server.dispatch(_request("rind/usage/summary", {"days": "week"})))
+    assert _last(server)["error"]["type"] == "InvalidRequest"
+    assert worker.summary_calls == [30]
+
+
+@pytest.mark.asyncio
+async def test_worker_usage_summary_reads_the_real_ledger(tmp_path, monkeypatch):
+    from agent.runtime.server.worker import RuntimeWorker
+
+    monkeypatch.setenv("RIND_HOME", str(tmp_path))
+    ledger = tmp_path / "usage.jsonl"
+    append_usage_record(ledger, {
+        "ts": "2026-09-10T10:00:00+00:00",
+        "session_id": "s1",
+        "model": "m1",
+        "sampling_kind": "assistant",
+        "input_tokens": 100,
+        "cached_input_tokens": 10,
+        "cache_hit_rate": 0.1,
+        "output_tokens": 20,
+        "reasoning_output_tokens": 5,
+        "total_tokens": 120,
+        "context_window_tokens": 4096,
+        "context_usage_percent": 100 / 4096,
+    })
+    append_usage_record(ledger, {
+        "ts": "2026-09-10T11:00:00+00:00",
+        "session_id": "s1",
+        "model": "m1",
+        "sampling_kind": "compact",
+        "input_tokens": 90,
+        "cached_input_tokens": 0,
+        "cache_hit_rate": 0.0,
+        "output_tokens": 30,
+        "reasoning_output_tokens": 0,
+        "total_tokens": 120,
+        "context_window_tokens": 4096,
+        "context_usage_percent": 90 / 4096,
+    })
+
+    worker = RuntimeWorker(workspace_root=str(tmp_path))
+    summary = await worker.usage_summary(7)
+
+    assert summary["days"] == 7
+    assert summary["totals"]["samples"] == 2
+    assert summary["totals"]["total"] == 240
+    assert summary["totals"]["compactions"] == 1
+    assert summary["totals"]["input"] == 190
+    assert summary["totals"]["output"] == 50
+    assert summary["by_model"][0]["model"] == "m1"
+    assert summary["by_model"][0]["tokens"] == 240
+    assert summary["recent_sessions"][0]["session_id"] == "s1"

--- a/test/test_runtime_server_protocol.py
+++ b/test/test_runtime_server_protocol.py
@@ -234,6 +234,8 @@ def test_golden_event_fixture_matches_python_envelope():
         "session/delete",
         "session/fork",
         "ping",
+        "rind/context/inspect",
+        "rind/usage/summary",
     ]
     assert responses == [
         {
@@ -285,6 +287,54 @@ def test_golden_event_fixture_matches_python_envelope():
             "kind": "response",
             "request_id": "ping-1",
             "result": {"ok": True},
+        },
+        {
+            "kind": "response",
+            "request_id": "context-inspect-1",
+            "result": {
+                "session_id": "session-1",
+                "breakdown": {
+                    "captured_at": "2026-01-01T00:00:04Z",
+                    "turn_id": "turn-1",
+                    "estimated_total": 120,
+                    "context_window_tokens": 1000,
+                    "sections": [
+                        {"key": "chat_user", "label": "Chat · user inputs", "tokens": 120, "messages": 1},
+                    ],
+                },
+                "latest_usage": {
+                    "sampling_kind": "assistant",
+                    "input_tokens": 118,
+                    "cached_input_tokens": 0,
+                    "cache_hit_rate": 0.0,
+                    "output_tokens": 21,
+                    "reasoning_output_tokens": 0,
+                    "total_tokens": 139,
+                    "context_window_tokens": 1000,
+                    "context_usage_percent": 0.118,
+                },
+            },
+        },
+        {
+            "kind": "response",
+            "request_id": "usage-summary-1",
+            "result": {
+                "days": 7,
+                "totals": {
+                    "input": 118,
+                    "cached": 0,
+                    "output": 21,
+                    "reasoning": 0,
+                    "total": 139,
+                    "samples": 1,
+                    "compactions": 0,
+                },
+                "by_day": [{"day": "01-01", "tokens": 139}],
+                "by_model": [{"model": "test-model", "tokens": 139, "samples": 1}],
+                "recent_sessions": [
+                    {"session_id": "session-1", "updated_at": "2026-01-01T00:00:04Z", "tokens": 139, "samples": 1},
+                ],
+            },
         },
     ]
 

--- a/test/test_usage_ledger.py
+++ b/test/test_usage_ledger.py
@@ -1,0 +1,206 @@
+"""Usage ledger append/load plus the capture chain wiring."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from agent.application.context.manager import ContextBuildResult
+from agent.application.context.token_usage import normalize_sampling_usage
+from agent.infrastructure.persistence.usage_ledger import append_usage_record, load_usage_records
+from agent.runtime.core.turn_runner import TurnRunner
+
+
+def test_appended_records_read_back(tmp_path):
+    path = tmp_path / "usage.jsonl"
+    append_usage_record(path, {"session_id": "s1", "total_tokens": 10})
+    append_usage_record(path, {"session_id": "s2", "total_tokens": 20})
+
+    records = load_usage_records(path)
+
+    assert [record["session_id"] for record in records] == ["s1", "s2"]
+    assert [record["total_tokens"] for record in records] == [10, 20]
+
+
+def test_concurrent_appends_never_interleave(tmp_path):
+    path = tmp_path / "usage.jsonl"
+    writers = 8
+    per_writer = 25
+
+    def _write(writer_index: int) -> None:
+        for step in range(per_writer):
+            append_usage_record(path, {"writer": writer_index, "step": step})
+
+    threads = [threading.Thread(target=_write, args=(index,)) for index in range(writers)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    records = load_usage_records(path)
+    assert len(records) == writers * per_writer
+    for record in records:
+        assert set(record) == {"writer", "step"}
+
+
+def _turn_with_capture(tmp_path, usage):
+    """Run one sampling turn with a breakdown-bearing context and a real ledger recorder."""
+    breakdowns = []
+
+    class FakeSession:
+        model = "test-model"
+        session_id = "20260910_test"
+
+        def __init__(self):
+            self.usages = []
+
+        async def get_turn_state(self):
+            return None
+
+        async def persist_turn_state(self, *args, **kwargs):
+            return None
+
+        def now_iso(self):
+            return "2026-09-10T00:00:00Z"
+
+        async def persist_message(self, *args, **kwargs):
+            return None
+
+        async def persist_sampling_usage(self, sampled):
+            self.usages.append(dict(sampled))
+
+        async def persist_context_breakdown(self, snapshot):
+            breakdowns.append(snapshot)
+
+    internal_messages = [
+        {"role": "system", "content": "system prompt " * 10},
+        {"role": "system", "content": "skills", "_context_kind": "skill_catalog"},
+        {"role": "user", "content": "run the tool"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "c1", "type": "function", "function": {"name": "bash", "arguments": "ls"}},
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "listing"},
+    ]
+    stripped = [
+        {key: value for key, value in message.items() if not key.startswith("_")}
+        for message in internal_messages
+    ]
+    stats = {"estimated_input_tokens": 150, "context_window_tokens": 4096}
+    context = ContextBuildResult(
+        messages=stripped,
+        stats=stats,
+        decisions={},
+        internal_messages=internal_messages,
+    )
+    mock_context = MagicMock()
+    mock_context.build_messages_async = AsyncMock(return_value=context)
+    mock_context.select_active_skills_for_turn = None
+
+    mock_client = AsyncMock()
+
+    class EmptyStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    mock_client.stream = MagicMock(return_value=EmptyStream())
+    mock_parser = MagicMock()
+    mock_parser.consume_async_stream = AsyncMock(return_value=("Done", [], usage, None, None))
+
+    ledger_path = tmp_path / "usage.jsonl"
+
+    def _recorder(record):
+        append_usage_record(ledger_path, record)
+
+    session = FakeSession()
+    runner = TurnRunner(
+        chat_client=mock_client,
+        tool_processor=MagicMock(),
+        stream_parser=mock_parser,
+        tool_schemas=[],
+        context_manager=mock_context,
+        usage_recorder=_recorder,
+    )
+    return runner, session, breakdowns, ledger_path
+
+
+@pytest.mark.asyncio
+async def test_turn_persists_breakdown_and_appends_measured_ledger_row(tmp_path):
+    usage = SimpleNamespace(
+        prompt_tokens=100,
+        completion_tokens=25,
+        total_tokens=125,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=40),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=5),
+    )
+    runner, session, breakdowns, ledger_path = _turn_with_capture(tmp_path, usage)
+
+    events = [event async for event in runner.run_turn(session, turn_id="turn-9")]
+
+    assert any(type(event).__name__ == "TurnCompletedEvent" for event in events)
+    # The breakdown of the last build lands in session meta storage.
+    assert len(breakdowns) == 1
+    breakdown = breakdowns[0]
+    assert breakdown["turn_id"] == "turn-9"
+    assert breakdown["estimated_total"] == 150
+    assert breakdown["context_window_tokens"] == 4096
+    assert any(section["key"] == "skill_catalog" for section in breakdown["sections"])
+    assert any(section["key"] == "tool:bash" for section in breakdown["sections"])
+    # The ledger row mirrors the measured normalize_sampling_usage output shape.
+    records = load_usage_records(ledger_path)
+    assert len(records) == 1
+    record = records[0]
+    normalized = normalize_sampling_usage(
+        usage,
+        sampling_kind="assistant",
+        context_window_tokens=4096,
+    )
+    for field, value in normalized.items():
+        if field == "anchor":
+            continue
+        assert record[field] == value
+    assert record["session_id"] == "20260910_test"
+    assert record["model"] == "test-model"
+    assert record["ts"]
+
+
+@pytest.mark.asyncio
+async def test_store_breakdown_overwrites_and_travels_with_fork(tmp_path):
+    from agent.infrastructure.persistence import fork_session
+    from agent.infrastructure.persistence.jsonl_session_store import JsonlSessionStore
+
+    store = JsonlSessionStore(
+        session_dir=str(tmp_path),
+        session_id="20260910_forkme",
+        system_prompt="sys",
+        workspace_root=str(tmp_path),
+    )
+    await store.initialize()
+    await store.persist_message("user", "hello")
+    await store.persist_context_breakdown({"turn_id": "first", "sections": []})
+    await store.persist_context_breakdown({
+        "turn_id": "second",
+        "estimated_total": 42,
+        "context_window_tokens": 100,
+        "sections": [{"key": "chat_user", "label": "Chat · user inputs", "tokens": 42, "messages": 1}],
+    })
+
+    meta = JsonlSessionStore.load_session_metadata("20260910_forkme", str(tmp_path))
+    # Overwrite = latest: meta holds the breakdown of the last assembled call.
+    assert meta["latest_context_breakdown"]["turn_id"] == "second"
+
+    forked = fork_session(tmp_path, "20260910_forkme")
+    forked_meta = JsonlSessionStore.load_session_metadata(forked, str(tmp_path))
+    assert forked_meta["latest_context_breakdown"]["estimated_total"] == 42

--- a/test/test_usage_summary.py
+++ b/test/test_usage_summary.py
@@ -126,6 +126,17 @@ def test_totals_reconcile_with_raw_rows():
     assert totals["total"] == 180
 
 
+def test_day_buckets_follow_the_record_own_offset():
+    # 01:00 on 09-10 in UTC+8 is 17:00 on 09-09 in UTC: a user's local calendar
+    # must win, so the row lands on their day, not the server's.
+    record = _record("2026-09-10T01:00:00+08:00", total=77)
+
+    summary = summarize_usage([record], 7, now=NOW)
+
+    assert [row["day"] for row in summary["by_day"]] == ["09-10"]
+    assert summary["by_day"][0]["tokens"] == 77
+
+
 def test_empty_ledger_yields_an_all_zero_structure():
     summary = summarize_usage([], 7, now=NOW)
 

--- a/test/test_usage_summary.py
+++ b/test/test_usage_summary.py
@@ -1,0 +1,157 @@
+"""Usage summary reduction rules over ledger records."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from agent.application.context.usage_summary import summarize_usage
+
+
+NOW = datetime(2026, 9, 10, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _record(ts, *, model="m1", session_id="s1", kind="assistant", total=100, **overrides):
+    record = {
+        "ts": ts,
+        "model": model,
+        "session_id": session_id,
+        "sampling_kind": kind,
+        "input_tokens": 60,
+        "cached_input_tokens": 20,
+        "output_tokens": 40,
+        "reasoning_output_tokens": 10,
+        "total_tokens": total,
+    }
+    record.update(overrides)
+    return record
+
+
+def _iso(dt):
+    return dt.isoformat()
+
+
+def test_records_group_by_day_within_the_window():
+    records = [
+        _record(_iso(NOW - timedelta(hours=1)), total=300),
+        _record(_iso(NOW - timedelta(days=1, hours=2)), total=200),
+        _record(_iso(NOW - timedelta(days=2, hours=3)), total=100),
+    ]
+
+    summary = summarize_usage(records, 7, now=NOW)
+
+    assert summary["days"] == 7
+    assert summary["totals"]["samples"] == 3
+    assert summary["totals"]["total"] == 600
+    assert [row["day"] for row in summary["by_day"]] == ["09-10", "09-09", "09-08"]
+    assert [row["tokens"] for row in summary["by_day"]] == [300, 200, 100]
+
+
+def test_days_filter_boundary_keeps_today_and_drops_day_eight():
+    inside = _record(_iso(NOW - timedelta(days=7)), total=50)
+    outside = _record(_iso(NOW - timedelta(days=8)), total=500)
+
+    summary = summarize_usage([inside, outside], 7, now=NOW)
+
+    assert summary["totals"]["samples"] == 1
+    assert summary["totals"]["total"] == 50
+    assert [row["day"] for row in summary["by_day"]] == ["09-03"]
+
+
+def test_by_model_adds_up_and_orders_by_volume():
+    records = [
+        _record(_iso(NOW), model="big", total=900),
+        _record(_iso(NOW), model="big", total=100),
+        _record(_iso(NOW), model="small", total=50),
+    ]
+
+    summary = summarize_usage(records, 7, now=NOW)
+
+    assert [(row["model"], row["tokens"], row["samples"]) for row in summary["by_model"]] == [
+        ("big", 1000, 2),
+        ("small", 50, 1),
+    ]
+    assert sum(row["tokens"] for row in summary["by_model"]) == summary["totals"]["total"]
+
+
+def test_compaction_samples_are_counted_separately():
+    records = [
+        _record(_iso(NOW), kind="assistant"),
+        _record(_iso(NOW), kind="compact"),
+        _record(_iso(NOW), kind="compact"),
+    ]
+
+    summary = summarize_usage(records, 7, now=NOW)
+
+    assert summary["totals"]["samples"] == 3
+    assert summary["totals"]["compactions"] == 2
+
+
+def test_recent_sessions_take_the_latest_five():
+    records = []
+    for index in range(7):
+        records.append(
+            _record(
+                _iso(NOW - timedelta(hours=index)),
+                session_id=f"s{index}",
+                total=10 + index,
+            )
+        )
+
+    summary = summarize_usage(records, 7, now=NOW)
+
+    assert [row["session_id"] for row in summary["recent_sessions"]] == ["s0", "s1", "s2", "s3", "s4"]
+    assert summary["recent_sessions"][0]["tokens"] == 10
+    assert summary["recent_sessions"][0]["updated_at"] == _iso(NOW)
+
+
+def test_totals_reconcile_with_raw_rows():
+    records = [
+        _record(_iso(NOW), total=120, input_tokens=80, cached_input_tokens=30, output_tokens=40, reasoning_output_tokens=7),
+        _record(_iso(NOW - timedelta(days=1)), total=60, input_tokens=40, cached_input_tokens=10, output_tokens=20, reasoning_output_tokens=3),
+    ]
+
+    summary = summarize_usage(records, 7, now=NOW)
+
+    totals = summary["totals"]
+    assert totals["input"] == 120
+    assert totals["cached"] == 40
+    assert totals["output"] == 60
+    assert totals["reasoning"] == 10
+    assert totals["total"] == 180
+
+
+def test_empty_ledger_yields_an_all_zero_structure():
+    summary = summarize_usage([], 7, now=NOW)
+
+    assert summary["days"] == 7
+    assert summary["totals"] == {
+        "input": 0,
+        "cached": 0,
+        "output": 0,
+        "reasoning": 0,
+        "total": 0,
+        "samples": 0,
+        "compactions": 0,
+    }
+    assert summary["by_day"] == []
+    assert summary["by_model"] == []
+    assert summary["recent_sessions"] == []
+
+
+def test_malformed_records_are_ignored():
+    records = [
+        "not-a-dict",
+        {"no_ts": True},
+        _record(_iso(NOW), total=42),
+    ]
+
+    summary = summarize_usage(records, 7, now=NOW)
+
+    assert summary["totals"]["samples"] == 1
+    assert summary["totals"]["total"] == 42


### PR DESCRIPTION
## What
- **Worker**: new protocol methods `rind/context/inspect` (session context breakdown anchored on the latest assistant sampling, sections follow assembly order) and `rind/usage/summary` (totals / by-day / by-model aggregates backed by a new append-only usage ledger at `~/.rind/usage.jsonl`)
- **CLI**: `/context` opens a two-page board (context breakdown + usage summary) with page navigation; local-offset timestamps; `~` marker on estimated values (estimated never masquerades as measured); persistent ctx gauge; `/context 30` explains the day-range fallback instead of failing as unknown command

## Tests
- Python: 93 passed (snapshot, usage ledger, usage summary, server dispatch, protocol surface, journey tests)
- JS: 307 passed (context board locked to visual spec, rendering, protocol)